### PR TITLE
Added loading screen until data is finished being fetched

### DIFF
--- a/src/components/BaseComponents/LoadingComponent.tsx
+++ b/src/components/BaseComponents/LoadingComponent.tsx
@@ -1,11 +1,29 @@
 import React from 'react';
+import { withStyles, createStyles } from '@material-ui/core/styles';
 
-const LoadingComponent = () => {
+const styles = () =>
+  createStyles({
+    loadingComponent: {
+      height: '100vh',
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      flexDirection: 'column',
+    },
+  });
+
+interface LoadingComponentProps {
+  classes: { loadingComponent: string };
+
+}
+
+const LoadingComponent = (props: LoadingComponentProps) => {
+  const { classes } = props;
   return (
-    <div>
+    <div className={classes.loadingComponent}>
       <h1> Loading ... </h1>
     </div>
   );
 };
 
-export default LoadingComponent;
+export default withStyles(styles)(LoadingComponent);

--- a/src/components/authentication/AuthenticatedRoute.tsx
+++ b/src/components/authentication/AuthenticatedRoute.tsx
@@ -27,7 +27,7 @@ const AuthenticatedRoute = ({ isLoading, isSignedIn, path, component, exact }: A
 };
 
 const mapStateToProps = (state: RootState) => ({
-  isLoading: state.userData.isLoading,
+  isLoading: state.userData.isLoading || state.siteData.isLoading,
   isSignedIn: state.userData.user !== null,
 });
 


### PR DESCRIPTION

Added loading page intermediate after login to not show home screen until data is fetched.

I think loading is taking a longer time than necessary because of unoptimized http calls (Maybe we should probably build out an API endpoint on the node server and have that do a bunch of calls and return the result?).


![loading-screen](https://user-images.githubusercontent.com/35501399/102032706-654a5800-3d6e-11eb-9b47-6cce4ae0d468.gif)

