### PR TITLE
Cleaned up env file and service worker uses environment file for network endpoint

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,4 @@
+AIRTABLE_EMAIL= # Needed when using the schema generator
+AIRTABLE_PASSWORD= # Needed when using the  schema generator
+REACT_APP_AIRTABLE_ENDPOINT_URL= # Point towards airlock server
 REACT_APP_AIRTABLE_BASE_ID=
-REACT_APP_AIRTABLE_API_KEY=
-# REACT_APP_AIRTABLE_ENDPOINT_URL

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "start": "react-scripts start",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
-    "build-sw": "node ./src/sw-build.js",
+    "build-sw": "node ./src/custom-sw/sw-env.js && node ./src/custom-sw/sw-build.js",
     "clean-cra-sw": "rm -f build/precache-manifest.*.js && rm -f build/service-worker.js",
     "build": "react-scripts build && npm run build-sw && npm run clean-cra-sw",
     "generate-schema": "generate-airtable-schema",

--- a/src/custom-sw/sw-build.js
+++ b/src/custom-sw/sw-build.js
@@ -5,7 +5,7 @@ const buildSW = () => {
     // sw install rules couldn't
     // be generated. Add catch for this.
     return workboxBuild.injectManifest({
-        swSrc: "src/sw-custom.js", // custom sw rule
+        swSrc: "src/custom-sw/sw-custom.js", // custom sw rule
         swDest: "build/sw.js", // sw output file (auto-generated)
         globDirectory: "build",
         globPatterns: ["**/*.{js,css,html,png,svg}"],

--- a/src/custom-sw/sw-custom.js
+++ b/src/custom-sw/sw-custom.js
@@ -3,6 +3,8 @@ if ("function" === typeof importScripts) {
         "https://storage.googleapis.com/workbox-cdn/releases/3.5.0/workbox-sw.js"
     );
 
+    importScripts('sw-env.js');
+
     // Global workbox
     if (workbox) {
         console.log("Workbox loaded");
@@ -41,7 +43,7 @@ if ("function" === typeof importScripts) {
         // Will add to bgSyncPlugin queue and will resend when network reconnect
         // TODO: Change to know routes once we know the routes needed to catch
         workbox.routing.registerRoute(
-            new RegExp("http://127.0.0.1:4000/(.+)"),
+            new RegExp(`${process.env.REACT_APP_AIRTABLE_ENDPOINT_URL}/(.+)`),
             new workbox.strategies.NetworkOnly({
                 plugins: [bgSyncPlugin]
             }),

--- a/src/custom-sw/sw-env.js
+++ b/src/custom-sw/sw-env.js
@@ -1,0 +1,19 @@
+require('dotenv').config();
+const fs = require('fs');
+
+// Transfers environment variables into build environment
+const transferEnvironmentVariables = () => {
+
+    fs.writeFileSync('build/sw-env.js',
+        `
+    const process = {
+        env: {
+            REACT_APP_AIRTABLE_ENDPOINT_URL: '${process.env.REACT_APP_AIRTABLE_ENDPOINT_URL}',
+            REACT_APP_AIRTABLE_BASE_ID: '${process.env.REACT_APP_AIRTABLE_BASE_ID}',
+        }
+    }
+    `
+    )
+}
+
+transferEnvironmentVariables();


### PR DESCRIPTION
Service worker used to catch failed network requests to a hardcoded URL endpoint. This PR changes that so that the service worker catches network requests to a URL endpoint specified by environment variables.

The transfer of environment variables was necessary because environment variables don't seem to be available to service workers in build environments. To remedy this, we manually transfer the environment variables of interest by writing to a JS file called `sw-env.js` during the `npm build` process.

**Note**: It's too out-of-the-way to properly test this in this PR (we require being able to send POST requests and making sure they're sent when back online). This PR doesn't test for that functionality. Instead, we will test that when PRs related to POST requests start landing (some time early next week).


### Testing PR
- run `npm run build` in the root directory
- Check that the resulting `build` file produced properly transfers the variables in the `.env` file into `build/sw-env.js`.
- Check that service workers still work when running `npm run build`
  - After building, run `serve -s build` and log in
  - Check for errors with service worker in devtools console
  - Turn off your network connection via devtools, cancel the `serve -s build` process
  - Go to `localhost:5000` and check that you still arrive a the home page
