### PR TITLE
Changed route names to be kebab-case and work with offline

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -37,17 +37,17 @@ function App(isSignedIn: AppProps) {
       <AuthenticatedRoute path="/home" component={Home} />
 
       <AuthenticatedRoute path="/customers" component={CustomerMain} exact />
-      <AuthenticatedRoute path="/customers/add" component={AddCustomer} />
-      <AuthenticatedRoute path={'/customers/:rid'} component={CustomerProfile} exact />
-      <AuthenticatedRoute path={'/customers/:rid/edit'} component={EditCustomer} />
-      <AuthenticatedRoute path="/customers/:rid/addMeter" component={AddMeterReading} />
-      <AuthenticatedRoute path={'/customers/:rid/records'} component={CustomerRecords} />
+      <AuthenticatedRoute path="/customers/create" component={AddCustomer} exact />
+      <AuthenticatedRoute path={'/customers/customer'} component={CustomerProfile} exact />
+      <AuthenticatedRoute path={'/customers/customer/edit'} component={EditCustomer} exact />
+      <AuthenticatedRoute path="/customers/customer/meter-readings/create" component={AddMeterReading} exact />
+      <AuthenticatedRoute path={'/customers/customer/records'} component={CustomerRecords} exact />
 
       <AuthenticatedRoute path="/inventory" component={Inventory} />
       <AuthenticatedRoute path="/maintenance" component={Maintenance} />
       <AuthenticatedRoute path="/incidents" component={Incidents} />
 
-      <AuthenticatedRoute path="/financialsummary" component={FinancialSummary} />
+      <AuthenticatedRoute path="/financial-summary" component={FinancialSummary} exact />
       <BaseNavigation />
     </>
   );

--- a/src/screens/Customers/CustomerMain.tsx
+++ b/src/screens/Customers/CustomerMain.tsx
@@ -102,7 +102,7 @@ function CustomerMain(props: RouteComponentProps & UserProps) {
       </div>
       <BaseScrollView>
         {filteredCustomers.map((customer, index) => (
-          <Link key={index} to={{ pathname: `${props.match.url}/${customer.name}`, state: { customer: customer } }}>
+          <Link key={index} to={{ pathname: `${props.match.url}/customer`, state: { customer: customer } }}>
             <CustomerCard name={customer.name} amount={customer.outstandingBalance} date={getLatestReadingDate(customer)} active={customer.isactive} />
           </Link>
         ))

--- a/src/screens/Customers/CustomerProfile.tsx
+++ b/src/screens/Customers/CustomerProfile.tsx
@@ -74,7 +74,7 @@ function CustomerProfile(props: CustomerProps) {
         <IconButton
           component={Link}
           to={{
-            pathname: `${match.url}/addMeter`,
+            pathname: `${match.url}/meter-readings/create`,
             state: { invoices: customer.meterReadings, payments: customer.payments },
           }}
           size="small"

--- a/src/screens/Home/Home.tsx
+++ b/src/screens/Home/Home.tsx
@@ -61,11 +61,11 @@ function Home(props: HomeProps) {
           ]}
         />
       </Link>
-      <Link to={'/financialsummary'}>
+      <Link to={'/financial-summary'}>
         <HomeMenuItem label="Unpaid Reports" amount={1} />
       </Link>
       <HomeMenuItem label="Unresolved Incidents" amount={0} />
-      <Link to={'/financialsummary'}>
+      <Link to={'/financial-summary'}>
         <HomeMenuItem label="Financial Summary" noBadge={true} />
       </Link>
     </BaseScreen>


### PR DESCRIPTION
Changed route names to be more CRUD-like (kebab-case and ending verbs).

Route have also been changed to not depend on `rid`. This is because users who are created offline do not receive an `rid` until they return online and are created on the Airtable. Therefore, we can't create routes based on `rid` because not all customers have it. Instead, because we store customer information anyways for offline use, we have a generic `/customers/customer` route that we can pass customer information to populate.

### To Test
- Ensure that all changed routes are still navigable (functionality preserved)
- Check convention