### PR TITLE
Profile dropdown and logout functionality 

### DIFF
--- a/src/components/BaseComponents/BaseHeader.tsx
+++ b/src/components/BaseComponents/BaseHeader.tsx
@@ -67,14 +67,6 @@ function BaseHeader(props: HeaderProps) {
     }
   };
 
-  const openMenu = (event: React.MouseEvent<HTMLElement>) => {
-    setAnchorEl(event.currentTarget);
-  };
-  
-  const closeMenu = () => {
-    setAnchorEl(null);
-  };
-
   const getIcon = (onClick: (event: React.MouseEvent<HTMLElement>) => void, icon: JSX.Element) => {
     return (
       <IconButton onClick={onClick} color="primary">
@@ -82,6 +74,23 @@ function BaseHeader(props: HeaderProps) {
       </IconButton>
     );
   };
+
+
+  const openProfileMenu = (event: React.MouseEvent<HTMLElement>) => {
+    setAnchorEl(event.currentTarget);
+  };
+  
+  const closeProfileMenu = () => {
+    setAnchorEl(null);
+  };
+
+  const profileMenu = (
+    <Menu anchorEl={anchorEl} keepMounted open={Boolean(anchorEl)} onClose={closeProfileMenu}>
+      <MenuItem>{name}</MenuItem>
+      <MenuItem>{email}</MenuItem>
+      <MenuItem onClick={handleLogoutClick}>Logout</MenuItem>
+    </Menu>
+  );
 
   const navigateToEdit = () => {
     history.push(`${match.url}/edit`);
@@ -91,7 +100,7 @@ function BaseHeader(props: HeaderProps) {
   const icons: { [key: string]: JSX.Element } = {
     backNav: getIcon(history.goBack, <ArrowBackIosIcon />),
     edit: getIcon(navigateToEdit, <CreateIcon />),
-    user: getIcon(openMenu, <AccountCircleIcon className={classes.account} fontSize="large" />),
+    user: getIcon(openProfileMenu, <AccountCircleIcon className={classes.account} fontSize="large" />),
   };
 
   const left = leftIcon ? icons[leftIcon] : null;
@@ -108,11 +117,7 @@ function BaseHeader(props: HeaderProps) {
       <div className={classes.toolbar}>
         <div className={classes.left}>{left}</div>
         <div className={classes.right}>{right}</div>
-        <Menu anchorEl={anchorEl} keepMounted open={Boolean(anchorEl)} onClose={closeMenu}>
-            <MenuItem>{name}</MenuItem>
-            <MenuItem>{email}</MenuItem>
-            <MenuItem onClick={handleLogoutClick}>Logout</MenuItem>
-        </Menu>
+        {profileMenu}
       </div>
     </div>
   );

--- a/src/components/BaseComponents/BaseHeader.tsx
+++ b/src/components/BaseComponents/BaseHeader.tsx
@@ -75,9 +75,9 @@ function BaseHeader(props: HeaderProps) {
     setAnchorEl(null);
   };
 
-  const getIcon = (onClick: (event: React.MouseEvent) => void, icon: JSX.Element) => {
+  const getIcon = (onClick: (event: React.MouseEvent<HTMLElement>) => void, icon: JSX.Element) => {
     return (
-      <IconButton onClick={openMenu} color="primary">
+      <IconButton onClick={onClick} color="primary">
         {icon}
       </IconButton>
     );
@@ -91,7 +91,7 @@ function BaseHeader(props: HeaderProps) {
   const icons: { [key: string]: JSX.Element } = {
     backNav: getIcon(history.goBack, <ArrowBackIosIcon />),
     edit: getIcon(navigateToEdit, <CreateIcon />),
-    user: getIcon(handleLogoutClick, <AccountCircleIcon className={classes.account} fontSize="large" />),
+    user: getIcon(openMenu, <AccountCircleIcon className={classes.account} fontSize="large" />),
   };
 
   const left = leftIcon ? icons[leftIcon] : null;

--- a/src/components/BaseComponents/BaseHeader.tsx
+++ b/src/components/BaseComponents/BaseHeader.tsx
@@ -1,12 +1,16 @@
-import React from 'react';
-import Typography from '@material-ui/core/Typography';
 import IconButton from '@material-ui/core/IconButton';
+import Menu from '@material-ui/core/Menu';
+import MenuItem from '@material-ui/core/MenuItem';
+import { createStyles, Theme, withStyles } from '@material-ui/core/styles';
+import Typography from '@material-ui/core/Typography';
+import AccountCircleIcon from '@material-ui/icons/AccountCircle';
 import ArrowBackIosIcon from '@material-ui/icons/ArrowBackIos';
 import CreateIcon from '@material-ui/icons/Create';
-import AccountCircleIcon from '@material-ui/icons/AccountCircle';
-import { withStyles, createStyles, Theme } from '@material-ui/core/styles';
+import React from 'react';
+import { connect } from 'react-redux';
 import { useHistory } from 'react-router-dom';
-
+import { logoutUser } from '../../lib/airlock/airlock';
+import { RootState } from '../../lib/redux/store';
 const styles = (theme: Theme) =>
   createStyles({
     root: {
@@ -44,15 +48,36 @@ export interface HeaderProps {
   rightIcon?: string;
   classes: any;
   match?: any;
+  name?: string;
+  email?: string;
 }
 
 function BaseHeader(props: HeaderProps) {
-  const { leftIcon, title, rightIcon, classes, match } = props;
+  const { leftIcon, title, rightIcon, classes, match, name, email } = props;
+  const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
+
   const history = useHistory();
+
+  const handleLogoutClick = async () => {
+    const logoutSuccess = await logoutUser();
+    if (logoutSuccess){
+      history.push('/login');
+    } else {
+      console.warn('Logout failed');
+    }
+  };
+
+  const openMenu = (event: React.MouseEvent<HTMLElement>) => {
+    setAnchorEl(event.currentTarget);
+  };
+  
+  const closeMenu = () => {
+    setAnchorEl(null);
+  };
 
   const getIcon = (onClick: (event: React.MouseEvent) => void, icon: JSX.Element) => {
     return (
-      <IconButton onClick={onClick} color="primary">
+      <IconButton onClick={openMenu} color="primary">
         {icon}
       </IconButton>
     );
@@ -66,10 +91,8 @@ function BaseHeader(props: HeaderProps) {
   const icons: { [key: string]: JSX.Element } = {
     backNav: getIcon(history.goBack, <ArrowBackIosIcon />),
     edit: getIcon(navigateToEdit, <CreateIcon />),
-    user: getIcon(empty, <AccountCircleIcon className={classes.account} fontSize="large" />),
+    user: getIcon(handleLogoutClick, <AccountCircleIcon className={classes.account} fontSize="large" />),
   };
-
-  function empty() {} //temporary empty function
 
   const left = leftIcon ? icons[leftIcon] : null;
   const header = title ? (
@@ -85,9 +108,19 @@ function BaseHeader(props: HeaderProps) {
       <div className={classes.toolbar}>
         <div className={classes.left}>{left}</div>
         <div className={classes.right}>{right}</div>
+        <Menu anchorEl={anchorEl} keepMounted open={Boolean(anchorEl)} onClose={closeMenu}>
+            <MenuItem>{name}</MenuItem>
+            <MenuItem>{email}</MenuItem>
+            <MenuItem onClick={handleLogoutClick}>Logout</MenuItem>
+        </Menu>
       </div>
     </div>
   );
 }
 
-export default withStyles(styles)(BaseHeader);
+const mapStateToProps = (state: RootState) => ({
+  name: state.userData.user?.fields.Name || '',
+  email: state.userData.user?.fields.Email || '',
+});
+
+export default connect(mapStateToProps)(withStyles(styles)(BaseHeader));

--- a/src/lib/airlock/airlock.ts
+++ b/src/lib/airlock/airlock.ts
@@ -1,5 +1,5 @@
 import { base } from '../airtable/airtable';
-import { refreshUserData } from '../redux/userData';
+import { clearUserData, refreshUserData } from '../redux/userData';
 
 const signupUser = async (username: string, password: string): Promise<{ success: boolean; message: string }> => {
   let success, message;
@@ -47,6 +47,7 @@ const logoutUser = async (): Promise<boolean> => {
     if (!res.body.success) {
       return false;
     }
+    clearUserData();
     return true;
   } catch (err) {
     console.log(err);

--- a/src/lib/redux/userData.ts
+++ b/src/lib/redux/userData.ts
@@ -1,7 +1,7 @@
-import { store } from './store';
-import { refreshSiteData } from './siteData';
-import { saveUserData, setLoadingForUserData, setIsOnline } from './userDataSlice';
 import $ from 'jquery';
+import { refreshSiteData } from './siteData';
+import { store } from './store';
+import { deauthenticateAndClearUserData, saveUserData, setIsOnline, setLoadingForUserData } from './userDataSlice';
 
 // TODO: Change from any when typing introduced
 const refreshUserData = async (user: any): Promise<void> => {
@@ -40,6 +40,10 @@ const getUserId = (): string => {
   }
 
   return userId;
+};
+
+export const clearUserData = (): void => {
+  store.dispatch(deauthenticateAndClearUserData());
 };
 
 export { refreshUserData, checkOnline, getUserId };

--- a/src/lib/redux/userDataSlice.ts
+++ b/src/lib/redux/userDataSlice.ts
@@ -53,8 +53,11 @@ const userDataSlice = createSlice({
       state.lastUpdated = moment().toString();
       state.isOnline = true;
     },
+    deauthenticateAndClearUserData() {
+      return { ...initialState };
+    }
   },
 });
 
-export const { setLoadingForUserData, saveUserData, setIsOnline } = userDataSlice.actions;
+export const { setLoadingForUserData, saveUserData, setIsOnline , deauthenticateAndClearUserData} = userDataSlice.actions;
 export default userDataSlice.reducer;


### PR DESCRIPTION
[//]: # "These comments are meant for your reference. They are invisible and don't need to be deleted!"

# What's new in this PR

Added basic profile dropdown and logout functionality. The profile is temporarily just a basic menu that displays Name, Email, and the Logout button.

Logout clears the user data through `deauthenticateAndClearUserData()` which resets to `initialState`.

[//]: # "Describe what's new in this PR in a few lines. A description and bullet points for specifics will suffice."

## How to review

- Log in and try logging out and make sure all user data is cleared (using inspector)
- Try different test users, especially users with and without names and/or emails

[//]: # 'The order in which to review files and what to expect when testing locally'

## Relevant Links

### Online sources

[//]: # 'Optional - copy links to any tutorial or documentation that was useful to you when working on this PR'

- Logout functionality from People Power https://github.com/calblueprint/peoplepower-web/tree/master/src

### Related PRs
n/a

[//]: # "Optional - related PRs you're waiting on/ PRs that will conflict, etc; if this is a refactor, feel free to add PRs that previously modified this code"

## Next steps

[//]: # "What's NOT in this PR, doesn't work yet, and/or still needs to be done"
- Update styling to match Figma -- replace Menu with a card layout and incorporate profile pictures

### Screenshots

![image](https://user-images.githubusercontent.com/21160510/108164437-a3813200-70a5-11eb-93f5-67cfde3cc11a.png)

cc: @julianrkung 
