### PR TITLE
Changed Customer to look for CustomerData

### DIFF
--- a/src/lib/airtable/patches/patch-schema.patch
+++ b/src/lib/airtable/patches/patch-schema.patch
@@ -15,7 +15,7 @@ index 7c751ee..7741ad7 100644
  		inventoryUpdateIds: {name:`Inventory Updates`, type:`foreignKey-many`},
  	},
  	"Sites": {
-+		customers: {name:`Customers`, type:`custom-object`},
++		customers: {name:`CustomerData`, type:`custom-object`},
 +		financialSummaries: {name: `FinancialSummaries`, type:`custom-object`},
 +		tariffPlans: {name:`TariffPlans`, type:`custom-object`},
  		name: {name:`Name`, type:`text`},

--- a/src/lib/airtable/schema.js
+++ b/src/lib/airtable/schema.js
@@ -35,7 +35,7 @@ export const Columns = {
 		inventoryUpdateIds: {name:`Inventory Updates`, type:`foreignKey-many`},
 	},
 	"Sites": {
-		customers: {name:`Customers`, type:`custom-object`},
+		customers: {name:`CustomerData`, type:`custom-object`},
 		financialSummaries: {name: `FinancialSummaries`, type:`custom-object`},
 		tariffPlans: {name:`TariffPlans`, type:`custom-object`},
 		name: {name:`Name`, type:`text`},


### PR DESCRIPTION
[//]: # "These comments are meant for your reference. They are invisible and don't need to be deleted!"

# What's new in this PR
Hotfix because the `Customer` property was being overloaded in the schema by both `CustomerId` and `customers`. This changes `customers` to look for `CustomerData` property instead.

related PR: https://github.com/calblueprint/meepanyar-node/pull/12 
[//]: # "Describe what's new in this PR in a few lines. A description and bullet points for specifics will suffice."

## How to review

[//]: # 'The order in which to review files and what to expect when testing locally'

## Relevant Links

### Online sources

[//]: # 'Optional - copy links to any tutorial or documentation that was useful to you when working on this PR'

### Related PRs

[//]: # "Optional - related PRs you're waiting on/ PRs that will conflict, etc; if this is a refactor, feel free to add PRs that previously modified this code"

## Next steps

[//]: # "What's NOT in this PR, doesn't work yet, and/or still needs to be done"

### Screenshots

[//]: # "Add screenshots of expected behavior - GIFs if you're feeling fancy!"

CC: @julianrkung

[//]: # 'This tags Julian as a default. Feel free to change, or add on anyone who you should be in on the conversation.'