### PR TITLE
Update Workbox V6 and Sevice worker caches all endpoints for offline

### DIFF
--- a/src/custom-sw/sw-custom.js
+++ b/src/custom-sw/sw-custom.js
@@ -26,6 +26,9 @@ if ("function" === typeof importScripts) {
         // all assets under build/ and 5MB sizes are precached.
         workbox.precaching.precacheAndRoute([]);
 
+        // React is an SPA, so all routes we define are cached and mapped into index.html
+        workbox.routing.registerNavigationRoute('/index.html')
+
         // Font caching
         workbox.routing.registerRoute(
             new RegExp("https://fonts.(?:.googlepis|gstatic).com/(.*)"),

--- a/src/custom-sw/sw-custom.js
+++ b/src/custom-sw/sw-custom.js
@@ -1,6 +1,6 @@
 if ("function" === typeof importScripts) {
     importScripts(
-        "https://storage.googleapis.com/workbox-cdn/releases/3.5.0/workbox-sw.js"
+        "https://storage.googleapis.com/workbox-cdn/releases/6.1.1/workbox-sw.js"
     );
 
     importScripts('sw-env.js');
@@ -18,7 +18,7 @@ if ("function" === typeof importScripts) {
             self.skipWaiting();
         });
 
-        const bgSyncPlugin = new workbox.backgroundSync.Plugin('PostQueue', {
+        const bgSyncPlugin = new workbox.backgroundSync.BackgroundSyncPlugin('PostQueue', {
             maxRetentionTime: 24 * 60 // Retry for max of 24 hours
         });
 
@@ -27,15 +27,17 @@ if ("function" === typeof importScripts) {
         workbox.precaching.precacheAndRoute([]);
 
         // React is an SPA, so all routes we define are cached and mapped into index.html
-        workbox.routing.registerNavigationRoute('/index.html')
+        const handler = workbox.precaching.createHandlerBoundToURL('/index.html');
+        const navigationRoute = new workbox.routing.NavigationRoute(handler);
+        workbox.routing.registerRoute(navigationRoute);
 
         // Font caching
         workbox.routing.registerRoute(
             new RegExp("https://fonts.(?:.googlepis|gstatic).com/(.*)"),
-            workbox.strategies.cacheFirst({
+            new workbox.strategies.CacheFirst({
                 cacheName: "googleapis",
                 plugins: [
-                    new workbox.expiration.Plugin({
+                    new workbox.expiration.ExpirationPlugin({
                         maxEntries: 30,
                     }),
                 ],
@@ -56,10 +58,10 @@ if ("function" === typeof importScripts) {
         // Image caching
         workbox.routing.registerRoute(
             /\.(?:png|gif|jpg|jpeg|svg)$/,
-            workbox.strategies.cacheFirst({
+            new workbox.strategies.CacheFirst({
                 cacheName: "images",
                 plugins: [
-                    new workbox.expiration.Plugin({
+                    new workbox.expiration.ExpirationPlugin({
                         maxEntries: 60,
                         maxAgeSeconds: 30 * 24 * 60 * 60, // 30 Days
                     }),
@@ -70,10 +72,10 @@ if ("function" === typeof importScripts) {
         // JS, CSS caching
         workbox.routing.registerRoute(
             /\.(?:js|css)$/,
-            workbox.strategies.staleWhileRevalidate({
+            new workbox.strategies.StaleWhileRevalidate({
                 cacheName: "static-resources",
                 plugins: [
-                    new workbox.expiration.Plugin({
+                    new workbox.expiration.ExpirationPlugin({
                         maxEntries: 60,
                         maxAgeSeconds: 20 * 24 * 60 * 60, // 20 Days
                     }),


### PR DESCRIPTION
[//]: # "These comments are meant for your reference. They are invisible and don't need to be deleted!"

# What's new in this PR
Previously, the service worker would only launch on the `/` endpoint. This can be shown on the `main` branch, where production builds will respond with `offline` page error when refreshing on anything other than the `/` endpoint. 

This PR expands the service worker URL scope to all frontend endpoints, so refreshes on endpoints other than the `/` when offline will still work. This PR also updates to Workbox v6. We were previously on workbox V3.

[//]: # "Describe what's new in this PR in a few lines. A description and bullet points for specifics will suffice."

## How to review
1. Run `npm run build` to build a production version of the app
2. Run `serve -s build` to run the production version of the app on localhost
3. Log into the app on localhost using the production site
4. Shut down the frontend server running on the terminal
5. Do a refresh of the app in browser and see that it still correctly loads
6. Open a new tab and type in an endpoint in the app and see it still correctly loads even with the frontend offline (I went to `http://localhost:5000/customers`)

[//]: # 'The order in which to review files and what to expect when testing locally'

## Relevant Links

### Online sources
Migration from V3 --> V6 Changelog
[Plugin name change](https://developers.google.com/web/tools/workbox/guides/migrations/migrate-from-v4#plugin_classes_renamed)
[Route caching navigation](https://developers.google.com/web/tools/workbox/guides/migrations/migrate-from-v4)
[Strategies constructor](https://developers.google.com/web/tools/workbox/guides/migrations/migrate-from-v3)

[//]: # 'Optional - copy links to any tutorial or documentation that was useful to you when working on this PR'

### Related PRs

[//]: # "Optional - related PRs you're waiting on/ PRs that will conflict, etc; if this is a refactor, feel free to add PRs that previously modified this code"

## Next steps

[//]: # "What's NOT in this PR, doesn't work yet, and/or still needs to be done"

### Screenshots

[//]: # "Add screenshots of expected behavior - GIFs if you're feeling fancy!"

CC: @julianrkung

[//]: # 'This tags Julian as a default. Feel free to change, or add on anyone who you should be in on the conversation.'