### PR TITLE
[Translation Support] Automatically detect device language and encoding scheme

### DIFF
--- a/src/lib/i18next/device.ts
+++ b/src/lib/i18next/device.ts
@@ -1,0 +1,29 @@
+/**
+ * Detect and return user device language. 
+ * @returns string shorthand for device language (e.g. "en-US" or "my_MM")
+ */
+export const detectLanguage = (): string => {
+    return navigator.language;
+}
+
+/**
+ * Supported encodings for Mee Panyar. 
+ */
+export enum LanguageEncoding { 
+    UNICODE,
+    ZAWGYI 
+}
+
+/**
+ * Detect and return user device encoding.
+ */
+export const detectEncoding = (): LanguageEncoding => {
+    const context = document.createElement('canvas').getContext('2d'); 
+    const kaWidth = context?.measureText('က').width;
+    const patSintWidth = context?.measureText('က္က').width;
+    if (kaWidth == patSintWidth) {
+        return LanguageEncoding.UNICODE;
+    } else {
+        return LanguageEncoding.ZAWGYI;
+    }
+}

--- a/src/lib/i18next/device.ts
+++ b/src/lib/i18next/device.ts
@@ -1,6 +1,6 @@
 /**
  * Detect and return user device language. 
- * @returns string shorthand for device language (e.g. "en-US" or "my_MM")
+ * @returns string shorthand for device language (e.g. "en-US" or "my")
  */
 export const detectLanguage = (): string => {
     return navigator.language;

--- a/src/lib/i18next/encodings.ts
+++ b/src/lib/i18next/encodings.ts
@@ -1,18 +1,9 @@
-/* Copyright 2017 Google LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/** 
+ * Return EncodingConverter class with encoding conversion rules,
+ * formatted according to the conventions in https://github.com/google/myanmar-tools
+ * 
+ * Currently supports conversion between Unicode and Zawgyi. 
  */
-
 
 // tslint:disable-next-line:interface-over-type-literal This is an object literal type that cannot be extended.
 type TranslitRule = {

--- a/src/lib/i18next/i18n.js
+++ b/src/lib/i18next/i18n.js
@@ -1,11 +1,11 @@
 import i18n from 'i18next';
 import { initReactI18next } from 'react-i18next';
+import { detectLanguage } from './device'; 
 import resources from './resources'; 
 
-// TODO Step 4: Interpret language based on user settings
 i18n.use(initReactI18next).init({
     resources: resources,
-    lng: "bur",
+    lng: detectLanguage(),
     fallbackLng: "en",
     interpolation: {
         escapeValue: false

--- a/src/lib/i18next/resources.js
+++ b/src/lib/i18next/resources.js
@@ -1,5 +1,9 @@
+/** 
+ * Return JavaScript object with translations,
+ * formatted according to the conventions in https://react.i18next.com/ 
+ */
 export default {
-    bur:{
+   my_MM:{
        translation:{
           "undefined":"undefined",
           "Cancel":"ဖျက်သိမ်းမည်",

--- a/src/lib/i18next/resources.js
+++ b/src/lib/i18next/resources.js
@@ -3,7 +3,7 @@
  * formatted according to the conventions in https://react.i18next.com/ 
  */
 export default {
-   my_MM:{
+   my:{
        translation:{
           "undefined":"undefined",
           "Cancel":"ဖျက်သိမ်းမည်",

--- a/src/lib/i18next/translator.ts
+++ b/src/lib/i18next/translator.ts
@@ -1,23 +1,13 @@
 import { useTranslation } from 'react-i18next';
-
-/* Encoder between Zawgyi and Unicode */ 
+import { LanguageEncoding, detectEncoding } from './device'; 
 import { EncodingConverter } from './encodings'; 
 const converter = new EncodingConverter(); 
-
-enum LanguageEncoding { 
-    UNICODE,
-    ZAWGYI 
-}
-
-/* Global variable that determines user encoding */
-// TODO Step 4: Interpret encoding based on user settings
-let userEncoding: LanguageEncoding = LanguageEncoding.UNICODE; 
 
 /* Custom React hook to handle language internationalization */
 export const useInternationalization = () => {
     const { t } = useTranslation();
     const intl = (text: string) => {
-        switch (userEncoding) {
+        switch (detectEncoding()) {
             case LanguageEncoding.ZAWGYI: 
                 return converter.unicodeToZawgyi(t(text)); 
             default: 


### PR DESCRIPTION
# What's new in this PR

In this PR, I address [step 4](https://www.notion.so/calblueprint/Translation-Support-Design-Document-7703018a8c4e403dab8aaa49d2a322e7#222323ac6b0b4ada80b8c801898abf1d) of our [roadmap for translation support](https://www.notion.so/calblueprint/Translation-Support-Design-Document-7703018a8c4e403dab8aaa49d2a322e7) by creating two helper functions that detect a device's language and encoding in `i18next/device/ts`. 

## How to review
Note, the following instructions are for Chrome users only. 
1. Follow the same testing instructions as in #57 on this branch. 
2. [Change the browser's primary language to Burmese](https://support.google.com/chrome/answer/173424?co=GENIE.Platform%3DDesktop&hl=en). Be sure to move `Burmese` to the top of your languages when configuring your Advanced settings. This will make `Burmese` the default language on your browser. 
<img width="691" alt="Screen Shot 2021-03-25 at 2 44 10 PM" src="https://user-images.githubusercontent.com/44735047/112548024-d2f81e00-8d78-11eb-88a7-5e233b8908b8.png">

3. Reopen your localhost with the Mee Panyar application. The text you applied the custom hook to in step 1 should now be in Burmese Unicode. 

## Relevant Links
- [Design document for translation support](https://www.notion.so/calblueprint/Translation-Support-Design-Document-7703018a8c4e403dab8aaa49d2a322e7) 

### Online sources
- [Detecting Myanmar Zawgyi and Unicode in a Javascript application](https://medium.com/@linmyatko/how-to-detect-myanmar-zawgyi-or-unicode-on-modern-frontend-javascript-apps-28d4a1a4a1eb) 

### Related PRs
- [Fetching and parsing translations](https://github.com/calblueprint/meepanyar-node/pull/10)
- #57 

## Next steps
- Propagating this hook throughout the entire app (essentially comes down to replacing any hardcoded strings with our new `useIntl` hook). 
- Updating the translations Airtable as necessary (currently only supports text in the Adalo app) 
- Changing locale abbreviation to `my` instead of `bur` in [fetch and parse function](https://github.com/calblueprint/meepanyar-node/pull/10)
- Regenerate `resources.js` files whenever doing production builds

### Screenshots
After following the steps above and restarting Chrome, the results remain the same as #57. 
<img width="341" alt="Screen Shot 2021-03-25 at 2 43 05 PM" src="https://user-images.githubusercontent.com/44735047/112548013-ca074c80-8d78-11eb-95fb-169a028976b9.png">


CC: @julianrkung