### PR TITLE
Customer Data uses Entity Adapter and Selectors

### DIFF
--- a/src/lib/airtable/request.js
+++ b/src/lib/airtable/request.js
@@ -23,10 +23,9 @@ import {
   getRecordById,
   deleteRecord,
 } from './airtable';
-import { editCustomerInRedux } from '../../lib/redux/siteData';
-import { addToOfflineCustomer } from '../utils/offlineUtils';
+import { editCustomerInRedux, addCustomerToRedux } from '../../lib/redux/customerData';
+import { addToOfflineCustomer, generateOfflineId } from '../utils/offlineUtils';
 import { addInventoryToRedux } from '../redux/inventoryData';
-import { generateOfflineInventoryId } from '../utils/inventoryUtils';
 
 /*
  ******* CREATE RECORDS *******
@@ -212,7 +211,7 @@ export const createInventory = async (inventory) => {
     console.log('Response for inventory: ', resp);
     await resp.json().then(data => inventoryId = data.id);
   } catch (err) {
-    inventoryId = generateOfflineInventoryId();
+    inventoryId = generateOfflineId();
     console.log('Error with create inventory request: ', err);
   }
   inventory.id = inventoryId;

--- a/src/lib/redux/customerData.ts
+++ b/src/lib/redux/customerData.ts
@@ -1,32 +1,29 @@
 import { CustomerRecord } from '../airtable/interface';
-import { addCustomer, setCurrentCustomerId, editCustomer, EMPTY_CUSTOMER } from './customerDataSlice';
+import { addCustomer, setCurrentCustomerId, editCustomer, selectCustomerById } from './customerDataSlice';
 import { getCurrentSiteId } from './siteData';
-import { store } from './store';
+import { RootState, store } from './store';
+import { createSelector } from '@reduxjs/toolkit';
 
-const addCustomerToRedux = (customer: CustomerRecord): void => {
+export const addCustomerToRedux = (customer: CustomerRecord): void => {
     const siteId = getCurrentSiteId();
     store.dispatch(addCustomer({ siteId, customer }));
 };
 
-const editCustomerInRedux = (customer: any): void => {
-    store.dispatch(editCustomer(customer));
+export const editCustomerInRedux = (customer: any): void => {
+    const customerUpdates = {
+        ...customer,
+        siteId: getCurrentSiteId()
+    }
+    store.dispatch(editCustomer(customerUpdates));
 };
 
-const setCurrentCustomerIdInRedux = (customerId: string): void => {
+export const setCurrentCustomerIdInRedux = (customerId: string): void => {
     store.dispatch(setCurrentCustomerId(customerId))
 }
 
-const getCurrentCustomer = (): CustomerRecord | undefined => {
-    // TODO: When changing to entity adapter, we can speed this up / use a Selector instead
-    const customers = getAllCustomersInSite();
-    const currentCustomerId = store.getState().customerData.currentCustomerId;
-    return customers.find(customer => customer.id === currentCustomerId);
-}
+export const selectCurrentCustomerId = (state: RootState) => state.customerData.currentCustomerId;
 
-const getAllCustomersInSite = (): CustomerRecord[] => {
-    const siteId = getCurrentSiteId();
-    const siteIdsToCustomers = store.getState().customerData.siteIdsToCustomers[siteId] || {};
-    return Object.values(siteIdsToCustomers);
-}
-
-export { setCurrentCustomerIdInRedux, addCustomerToRedux, getAllCustomersInSite, editCustomerInRedux, getCurrentCustomer };
+export const selectCurrentCustomer = createSelector(
+    selectCurrentCustomerId, 
+    store.getState, 
+    (currentCustomerId, state) => selectCustomerById(state, currentCustomerId));

--- a/src/lib/redux/customerData.ts
+++ b/src/lib/redux/customerData.ts
@@ -9,7 +9,7 @@ export const addCustomerToRedux = (customer: CustomerRecord): void => {
     store.dispatch(addCustomer({ siteId, customer }));
 };
 
-export const editCustomerInRedux = (customer: any): void => {
+export const editCustomerInRedux = (customer: Partial<CustomerRecord>): void => {
     const customerUpdates = {
         ...customer,
         siteId: getCurrentSiteId()

--- a/src/lib/redux/customerDataSlice.ts
+++ b/src/lib/redux/customerDataSlice.ts
@@ -32,17 +32,17 @@ export const {
     selectById: selectCustomerById,
     selectIds: selectCustomerIds
 } = customersAdapter.getSelectors(
-    (state: RootState) => state.customerData.customers[state.siteData.currentSite.id]);
+    (state: RootState) => state.customerData.sitesCustomers[state.siteData.currentSite.id]);
 
 // TODO: @julianrkung, We should eventually make this a Record<SiteId, Record<CustomerId, CustomerRecord>> map for efficiency
 // We can't do this yet because customers created while offline do not receive an id yet
 interface customerDataSliceState {
-    customers: Record<SiteId, EntityState<CustomerRecord>>;
+    sitesCustomers: Record<SiteId, EntityState<CustomerRecord>>;
     currentCustomerId: string;
 }
 
 const initialState: customerDataSliceState = {
-    customers: {},
+    sitesCustomers: {},
     currentCustomerId: EMPTY_CUSTOMER.id,
 };
 
@@ -52,8 +52,8 @@ const customerDataSlice = createSlice({
     reducers: {
         saveCustomerData(state, action) {
             for (const [siteId, siteCustomers] of Object.entries(action.payload)) {
-                state.customers[siteId] = customersAdapter.getInitialState();
-                state.customers[siteId] = customersAdapter.addMany(state.customers[siteId], siteCustomers as CustomerRecord[]);
+                state.sitesCustomers[siteId] = customersAdapter.getInitialState();
+                state.sitesCustomers[siteId] = customersAdapter.addMany(state.sitesCustomers[siteId], siteCustomers as CustomerRecord[]);
             }
         },
         setCurrentCustomerId(state, action) {
@@ -63,7 +63,7 @@ const customerDataSlice = createSlice({
             const customer: CustomerRecord = action.payload.customer;
             const siteId: SiteId = action.payload.siteId;
 
-            customersAdapter.addOne(state.customers[siteId], customer);
+            customersAdapter.addOne(state.sitesCustomers[siteId], customer);
         },
         editCustomer(state, action) {
             const { siteId, id, ...changes } = action.payload;
@@ -71,7 +71,7 @@ const customerDataSlice = createSlice({
                 id,
                 changes,
             };
-            customersAdapter.updateOne(state.customers[siteId], update);
+            customersAdapter.updateOne(state.sitesCustomers[siteId], update);
         }
     },
     extraReducers: {

--- a/src/lib/redux/siteDataSlice.ts
+++ b/src/lib/redux/siteDataSlice.ts
@@ -6,7 +6,6 @@ import { SiteRecord, CustomerRecord, FinancialSummaryRecord } from '../airtable/
 interface siteDataSliceState {
   isLoading: boolean;
   currentSite: any; //TODO: Set as SiteRecord | null and resolve errors
-  currentCustomer: CustomerRecord | null;
   sites: any[];
 }
 
@@ -14,7 +13,6 @@ interface siteDataSliceState {
 const initialState: siteDataSliceState = {
   isLoading: false,
   currentSite: null,
-  currentCustomer: null,
   sites: [],
 };
 

--- a/src/screens/Customers/CustomerMain.tsx
+++ b/src/screens/Customers/CustomerMain.tsx
@@ -76,15 +76,13 @@ function CustomerMain(props: CustomerMainProps) {
   const { classes } = props;
   const [filteredCustomers, setFilteredCustomers] = useState<CustomerRecord[]>([]);
   const [filteredCustomersAlt, setFilteredCustomersAlt] = useState<CustomerRecord[]>([]);
-  const [fullCustomers, setFullCustomers] = useState<CustomerRecord[]>([]);
   const [allCustomersTrie, setAllCustomersTrie] = useState<TrieTree<CustomerRecord>>(new TrieTree('name'));
   const [sortBy, setSortBy] = useState<SortBy>(SortBy.NAME);
   const [filterBy, setFilterBy] = useState<FilterBy>(FilterBy.ACTIVE_STATUS);
   const [sortAndFilter, setSortAndFilter] = useState<string[]>([])
   const [filterLabels, setFilterLabels] = useState<string[]>(labels["ACTIVE_STATUS"]);
   const [searchValue, setSearchValue] = useState<string>("");
-
-  let allCustomers: CustomerRecord[] = useSelector(selectAllCustomersArray);
+  const fullCustomers = useSelector(selectAllCustomersArray) || [];
 
   useEffect(() => {
     getCustomers();
@@ -92,7 +90,8 @@ function CustomerMain(props: CustomerMainProps) {
   }, [sortBy, filterBy, searchValue]);
 
   const getCustomers = () => {
-    setFullCustomers(allCustomers);
+    let allCustomers = fullCustomers;
+
     if (searchValue !== '') {
       allCustomers = allCustomersTrie.get(searchValue);
     }

--- a/src/screens/Customers/CustomerMain.tsx
+++ b/src/screens/Customers/CustomerMain.tsx
@@ -1,16 +1,16 @@
 import { createStyles, Fab, FormControl, FormHelperText, ListSubheader, MenuItem, Select, Theme, withStyles } from '@material-ui/core';
 import AddIcon from '@material-ui/icons/Add';
 import React, { useEffect, useState } from 'react';
+import { useSelector } from 'react-redux';
 import { Link, RouteComponentProps } from 'react-router-dom';
 import BaseScreen from '../../components/BaseComponents/BaseScreen';
 import BaseScrollView from '../../components/BaseComponents/BaseScrollView';
 import CustomerCard from '../../components/CustomerCard';
 import UserSearchBar from '../../components/UserSearchBar';
 import { CustomerRecord } from '../../lib/airtable/interface';
-import { getAllCustomersInSite, setCurrentCustomerIdInRedux } from '../../lib/redux/customerData';
+import { setCurrentCustomerIdInRedux } from '../../lib/redux/customerData';
+import { selectAllCustomersArray } from '../../lib/redux/customerDataSlice';
 import TrieTree from '../../lib/utils/TrieTree';
-import { RootState } from '../../lib/redux/store';
-import { connect } from 'react-redux';
 
 
 const styles = (theme: Theme) =>
@@ -73,7 +73,7 @@ const labels: FilterByLabel = {
 }
 
 function CustomerMain(props: CustomerMainProps) {
-  const { classes, customers } = props;
+  const { classes } = props;
   const [filteredCustomers, setFilteredCustomers] = useState<CustomerRecord[]>([]);
   const [filteredCustomersAlt, setFilteredCustomersAlt] = useState<CustomerRecord[]>([]);
   const [fullCustomers, setFullCustomers] = useState<CustomerRecord[]>([]);
@@ -84,17 +84,14 @@ function CustomerMain(props: CustomerMainProps) {
   const [filterLabels, setFilterLabels] = useState<string[]>(labels["ACTIVE_STATUS"]);
   const [searchValue, setSearchValue] = useState<string>("");
 
+  let allCustomers: CustomerRecord[] = useSelector(selectAllCustomersArray);
+
   useEffect(() => {
     getCustomers();
     setSortAndFilter([SortBy[sortBy], FilterBy[filterBy]]);
   }, [sortBy, filterBy, searchValue]);
 
   const getCustomers = () => {
-    // TODO: It'd be better to slice once and store the sliced list somewhere.
-    // We need to slice here because redux freezes objects to prevent mutation.
-    // The slice occurs during each component update, so it's inefficient as number of
-    // customers or updates grows. This isn't predicted to be a huge issue but may be in the future.
-    let allCustomers: CustomerRecord[] = customers.slice();
     setFullCustomers(allCustomers);
     if (searchValue !== '') {
       allCustomers = allCustomersTrie.get(searchValue);
@@ -243,8 +240,4 @@ function CustomerMain(props: CustomerMainProps) {
 
 }
 
-const mapStateToProps = (state: RootState) => ({
-  customers: getAllCustomersInSite()
-});
-
-export default connect(mapStateToProps)(withStyles(styles)(CustomerMain));
+export default withStyles(styles)(CustomerMain);

--- a/src/screens/Customers/CustomerMain.tsx
+++ b/src/screens/Customers/CustomerMain.tsx
@@ -82,7 +82,7 @@ function CustomerMain(props: CustomerMainProps) {
   const [sortAndFilter, setSortAndFilter] = useState<string[]>([])
   const [filterLabels, setFilterLabels] = useState<string[]>(labels["ACTIVE_STATUS"]);
   const [searchValue, setSearchValue] = useState<string>("");
-  const fullCustomers = useSelector(selectAllCustomersArray) || [];
+  const fullCustomers : CustomerRecord[] = useSelector(selectAllCustomersArray) || [];
 
   useEffect(() => {
     getCustomers();

--- a/src/screens/Customers/CustomerProfile.tsx
+++ b/src/screens/Customers/CustomerProfile.tsx
@@ -12,7 +12,6 @@ import BaseScrollView from '../../components/BaseComponents/BaseScrollView';
 import OutlinedCardList, { CardPropsInfo } from '../../components/OutlinedCardList';
 import { CustomerRecord, MeterReadingRecord, SiteRecord } from '../../lib/airtable/interface';
 import { EMPTY_SITE } from '../../lib/redux/siteDataSlice';
-import { EMPTY_CUSTOMER } from '../../lib/redux/customerDataSlice';
 import { RootState } from '../../lib/redux/store';
 import { getAmountBilled, getCurrentReading, getPeriodUsage, getStartingReading, getTariffPlan } from '../../lib/utils/customerUtils';
 import { selectCurrentCustomer } from '../../lib/redux/customerData';
@@ -54,9 +53,9 @@ interface CustomerProps extends RouteComponentProps {
 
 function CustomerProfile(props: CustomerProps) {
   const { classes, match, currentSite } = props;
-  const customer : CustomerRecord = useSelector(selectCurrentCustomer) || EMPTY_CUSTOMER;
+  const customer = useSelector(selectCurrentCustomer);
 
-  if (customer === EMPTY_CUSTOMER) {
+  if (!customer) {
     return <Redirect to={'/customers'} />;
   }
 

--- a/src/screens/Customers/CustomerProfile.tsx
+++ b/src/screens/Customers/CustomerProfile.tsx
@@ -5,8 +5,8 @@ import React from 'react';
 import Typography from '@material-ui/core/Typography';
 import AddIcon from '@material-ui/icons/Add';
 import ListAltOutlinedIcon from '@material-ui/icons/ListAltOutlined';
-import { connect } from 'react-redux';
-import { Link, RouteComponentProps } from 'react-router-dom';
+import { connect, useSelector } from 'react-redux';
+import { Link, Redirect, RouteComponentProps } from 'react-router-dom';
 import BaseScreen from '../../components/BaseComponents/BaseScreen';
 import BaseScrollView from '../../components/BaseComponents/BaseScrollView';
 import OutlinedCardList, { CardPropsInfo } from '../../components/OutlinedCardList';
@@ -15,7 +15,7 @@ import { EMPTY_SITE } from '../../lib/redux/siteDataSlice';
 import { EMPTY_CUSTOMER } from '../../lib/redux/customerDataSlice';
 import { RootState } from '../../lib/redux/store';
 import { getAmountBilled, getCurrentReading, getPeriodUsage, getStartingReading, getTariffPlan } from '../../lib/utils/customerUtils';
-import { getCurrentCustomer } from '../../lib/redux/customerData';
+import { selectCurrentCustomer } from '../../lib/redux/customerData';
 
 const styles = (theme: Theme) =>
   createStyles({
@@ -53,7 +53,12 @@ interface CustomerProps extends RouteComponentProps {
 }
 
 function CustomerProfile(props: CustomerProps) {
-  const { classes, match, currentSite, customer } = props;
+  const { classes, match, currentSite } = props;
+  const customer : CustomerRecord = useSelector(selectCurrentCustomer) || EMPTY_CUSTOMER;
+
+  if (customer === EMPTY_CUSTOMER) {
+    return <Redirect to={'/customers'} />;
+  }
 
   // data retrieval
   const UNDEFINED_AMOUNT = '-';
@@ -163,7 +168,6 @@ function CustomerProfile(props: CustomerProps) {
 
 const mapStateToProps = (state: RootState) => ({
   currentSite: state.siteData.currentSite || EMPTY_SITE,
-  customer: getCurrentCustomer() || EMPTY_CUSTOMER,
 });
 
 export default connect(mapStateToProps)(withStyles(styles)(CustomerProfile));

--- a/src/screens/Customers/EditCustomer.tsx
+++ b/src/screens/Customers/EditCustomer.tsx
@@ -13,7 +13,7 @@ import { CustomerRecord, SiteRecord, CustomerUpdateRecord } from '../../lib/airt
 import { formatUTCDateStringToLocal } from '../../lib/moment/momentUtils';
 import { EMPTY_CUSTOMER, setCurrentCustomerId } from '../../lib/redux/customerDataSlice';
 import { EMPTY_SITE } from '../../lib/redux/siteDataSlice';
-import { User, EMPTY_USER } from '../../lib/redux/userDataSlice';
+import { selectCurrentUserId } from '../../lib/redux/userData';
 import { selectCurrentCustomer } from '../../lib/redux/customerData';
 
 const styles = (theme: Theme) =>
@@ -34,14 +34,14 @@ interface EditCustomerProps extends RouteComponentProps {
   classes: { header: string; content: string; formControl: string; };
   location: any;
   currentSite: SiteRecord;
-  user: User;
 }
 
 function EditCustomer(props: EditCustomerProps) {
-  const { classes, currentSite, user } = props;
+  const { classes, currentSite } = props;
   const history = useHistory();
 
   const currentCustomer = useSelector(selectCurrentCustomer) || EMPTY_CUSTOMER;
+  const userId = useSelector(selectCurrentUserId);
 
   const [selectedTariffPlanId, setSelectedTariffPlanId] = useState(currentCustomer.tariffPlanId);
   const [customerName, setCustomerName] = useState(currentCustomer.name);
@@ -70,7 +70,7 @@ function EditCustomer(props: EditCustomerProps) {
       dateUpdated: formatUTCDateStringToLocal((new Date()).toString()),
       customerId: currentCustomer.id,
       explanation: explanation,
-      userId: user.id,
+      userId: userId,
     };
 
     // Make a deep copy of an empty customer record
@@ -126,7 +126,6 @@ function EditCustomer(props: EditCustomerProps) {
 
 const mapStateToProps = (state: RootState) => ({
   currentSite: state.siteData.currentSite || EMPTY_SITE,
-  user: state.userData.user || EMPTY_USER,
 });
 
 export default connect(mapStateToProps)(withStyles(styles)(EditCustomer));

--- a/src/screens/Customers/EditCustomer.tsx
+++ b/src/screens/Customers/EditCustomer.tsx
@@ -1,8 +1,8 @@
 import { createStyles, FormControl, InputLabel, Theme, MenuItem, Select } from '@material-ui/core';
 import { withStyles } from '@material-ui/core/styles';
 import React, { useState } from 'react';
-import { connect } from 'react-redux';
-import { RouteComponentProps, useHistory } from 'react-router-dom';
+import { connect, useSelector } from 'react-redux';
+import { RouteComponentProps, useHistory, Redirect } from 'react-router-dom';
 import BaseScreen from '../../components/BaseComponents/BaseScreen';
 import Button from '../../components/Button';
 import Checkbox from '../../components/Checkbox';
@@ -11,10 +11,10 @@ import { editCustomer } from '../../lib/airtable/request';
 import { RootState } from '../../lib/redux/store';
 import { CustomerRecord, SiteRecord, CustomerUpdateRecord } from '../../lib/airtable/interface';
 import { formatUTCDateStringToLocal } from '../../lib/moment/momentUtils';
-import { EMPTY_CUSTOMER } from '../../lib/redux/customerDataSlice';
+import { EMPTY_CUSTOMER, setCurrentCustomerId } from '../../lib/redux/customerDataSlice';
 import { EMPTY_SITE } from '../../lib/redux/siteDataSlice';
 import { User, EMPTY_USER } from '../../lib/redux/userDataSlice';
-import { getCurrentCustomer } from '../../lib/redux/customerData';
+import { selectCurrentCustomer } from '../../lib/redux/customerData';
 
 const styles = (theme: Theme) =>
   createStyles({
@@ -39,8 +39,10 @@ interface EditCustomerProps extends RouteComponentProps {
 }
 
 function EditCustomer(props: EditCustomerProps) {
-  const { classes, currentCustomer, currentSite, user } = props;
+  const { classes, currentSite, user } = props;
   const history = useHistory();
+
+  const currentCustomer = useSelector(selectCurrentCustomer) || EMPTY_CUSTOMER;
 
   const [selectedTariffPlanId, setSelectedTariffPlanId] = useState(currentCustomer.tariffPlanId);
   const [customerName, setCustomerName] = useState(currentCustomer.name);
@@ -49,6 +51,10 @@ function EditCustomer(props: EditCustomerProps) {
   // TODO: @julianrkung Look into constraints on meter number input.
   const [meterNumber, setMeterNumber] = useState(currentCustomer.meterNumber);
   const [customerInactive, setCustomerInactive] = useState(!currentCustomer.isactive);
+
+  if (currentCustomer === EMPTY_CUSTOMER) {
+    return <Redirect to={'/customers'} />;
+  }
 
   const handleSelectTariffPlan = (event: React.ChangeEvent<{ value: unknown }>) => {
     setSelectedTariffPlanId(event.target.value as string);
@@ -78,7 +84,10 @@ function EditCustomer(props: EditCustomerProps) {
     // TODO: add error handling
     // We goBack instead of replace so there aren't 2 
     // "/customers/customer" routes in the history stack
-    editCustomer(customer, customerUpdate).then(history.goBack);
+    editCustomer(customer, customerUpdate).then(() => {
+      setCurrentCustomerId(customer.id);
+      history.goBack();
+    });
   }
 
   const handleNameInput = (event: React.ChangeEvent<{ value: unknown }>) => {
@@ -117,7 +126,6 @@ function EditCustomer(props: EditCustomerProps) {
 }
 
 const mapStateToProps = (state: RootState) => ({
-  currentCustomer: getCurrentCustomer() || EMPTY_CUSTOMER,
   currentSite: state.siteData.currentSite || EMPTY_SITE,
   user: state.userData.user || EMPTY_USER,
 });

--- a/src/screens/Customers/EditCustomer.tsx
+++ b/src/screens/Customers/EditCustomer.tsx
@@ -33,7 +33,6 @@ const styles = (theme: Theme) =>
 interface EditCustomerProps extends RouteComponentProps {
   classes: { header: string; content: string; formControl: string; };
   location: any;
-  currentCustomer: CustomerRecord;
   currentSite: SiteRecord;
   user: User;
 }

--- a/src/screens/Home/Home.tsx
+++ b/src/screens/Home/Home.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { connect } from 'react-redux';
+import { connect, useSelector } from 'react-redux';
 import { RootState } from '../../lib/redux/store';
 import { formatUTCDateStringToLocal } from '../../lib/moment/momentUtils';
 import { withStyles, createStyles } from '@material-ui/core/styles';
@@ -14,6 +14,8 @@ import Typography from '@material-ui/core/Typography';
 import WifiIcon from '@material-ui/icons/Wifi';
 import WifiOffIcon from '@material-ui/icons/WifiOff';
 import BaseScreen from '../../components/BaseComponents/BaseScreen';
+import { CustomerRecord } from '../../lib/airtable/interface';
+import { selectAllCustomersArray } from '../../lib/redux/customerDataSlice';
 
 const styles = () =>
   createStyles({
@@ -38,13 +40,13 @@ interface HomeProps {
 
 function Home(props: HomeProps) {
   const { classes, lastUpdated, isOnline, currentSite } = props;
+  const customers : CustomerRecord[] = useSelector(selectAllCustomersArray) || [];
 
   const calculateCustomerData = () => {
     // customers to charge:  haven't charged yet / no meter reading
     // outstanding payments: done the meter reading / charged, haven't paid yet
     let numCustomersToCharge = 0;
     let numOutstandingPayments = 0;
-    const customers = currentSite.customers || [];
     for (let i = 0; i < customers.length; i++) {
       const currCustomer = customers[i]
       //depends if the meter readings list is sorted with earliest => latest


### PR DESCRIPTION
[//]: # "These comments are meant for your reference. They are invisible and don't need to be deleted!"

# What's new in this PR
- This PR makes `customerDataSlice` consistent with `inventoryDataSlice` from this [PR](https://github.com/calblueprint/meepanyar/pull/60).
- Makes the customerData use an entity adapter
- Create selectors to be able to select from `customerData`
- Refactored so that customer-related screens use selectors

[//]: # "Describe what's new in this PR in a few lines. A description and bullet points for specifics will suffice."

## How to review
### Adding a Customer
- Create a customer for a site
- Ensure in the redux store that the customer has a proper Airtable record ID
- Check the backend that the customer was properly created in the correct site

### Editing a Customer
- Edit the customer (can be the customer created from the "Adding a Customer" section)
- Ensure the edit is persisted on the frontend (Customer Main, Customer Profile) and redux store
- Ensure that a "Customer update" was created in Airtable and the customer record is properly edited

### Redirects
- Change the site to reset the "CurrentCustomerId" value in redux
- Go to `/customers/customer` via the URL bar and make sure it redirects you to `/customers`
- Go to `/customers/customer/edit` via the URL bar and make sure it redirects you to `/customers`

[//]: # 'The order in which to review files and what to expect when testing locally'

## Relevant Links

### Online sources
Resources from Annie's PR: https://github.com/calblueprint/meepanyar/pull/60

[//]: # 'Optional - copy links to any tutorial or documentation that was useful to you when working on this PR'

### Related PRs
https://github.com/calblueprint/meepanyar/pull/60

[//]: # "Optional - related PRs you're waiting on/ PRs that will conflict, etc; if this is a refactor, feel free to add PRs that previously modified this code"

## Next steps
- Found a bug with the customer search. It doesn't handle deleting then re-entering different characters well.
  - Ex: In "East Asian Library" site, you can search "Al..." to narrow the search, then delete the "l" and add a space to attempt to search for the "A new customer" customer, but nothing will show up.
- Refactor SiteData to also use selectors 

[//]: # "What's NOT in this PR, doesn't work yet, and/or still needs to be done"

### Screenshots

[//]: # "Add screenshots of expected behavior - GIFs if you're feeling fancy!"

CC: @julianrkung

[//]: # 'This tags Julian as a default. Feel free to change, or add on anyone who you should be in on the conversation.'