### PR TITLE
[Inventory] Integrate camera functionality for purchase request receipts

### DIFF
--- a/src/components/BaseComponents/BaseHeader.tsx
+++ b/src/components/BaseComponents/BaseHeader.tsx
@@ -50,14 +50,15 @@ export interface HeaderProps {
   match?: any;
   name?: string;
   email?: string;
+  backAction?: () => void;
 }
 
 function BaseHeader(props: HeaderProps) {
-  const { leftIcon, title, rightIcon, classes, match, name, email } = props;
+  const { leftIcon, title, rightIcon, classes, match, name, email, backAction } = props;
   const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
 
   const history = useHistory();
-
+  const backActionDefault = history.goBack;
   const handleLogoutClick = async () => {
     const logoutSuccess = await logoutUser();
     if (logoutSuccess){
@@ -98,7 +99,7 @@ function BaseHeader(props: HeaderProps) {
 
   //TODO: allow users to input icons rather than map strings to icons
   const icons: { [key: string]: JSX.Element } = {
-    backNav: getIcon(history.goBack, <ArrowBackIosIcon />),
+    backNav: getIcon(backAction || backActionDefault, <ArrowBackIosIcon />),
     edit: getIcon(navigateToEdit, <CreateIcon />),
     user: getIcon(openProfileMenu, <AccountCircleIcon className={classes.account} fontSize="large" />),
   };

--- a/src/components/BaseComponents/BaseScreen.tsx
+++ b/src/components/BaseComponents/BaseScreen.tsx
@@ -1,6 +1,6 @@
+import { createStyles, withStyles } from '@material-ui/core/styles';
 import React from 'react';
 import BaseHeader, { HeaderProps } from './BaseHeader';
-import { withStyles, createStyles, Theme } from '@material-ui/core/styles';
 
 const styles = () =>
   createStyles({
@@ -19,11 +19,11 @@ interface BaseScreenProps extends HeaderProps {
 }
 
 const BaseScreen: React.FC<BaseScreenProps> = (props) => {
-  const { classes, leftIcon, title, rightIcon, match } = props;
+  const { classes, leftIcon, title, rightIcon, match, backAction } = props;
 
   return (
     <>
-      <BaseHeader leftIcon={leftIcon} title={title} rightIcon={rightIcon} match={match} />
+      <BaseHeader leftIcon={leftIcon} title={title} rightIcon={rightIcon} match={match} backAction={backAction}/>
       <div className={classes.content}>{props.children}</div>
     </>
   );

--- a/src/components/CameraButton.tsx
+++ b/src/components/CameraButton.tsx
@@ -19,18 +19,19 @@ const styles = (theme: Theme) =>
 interface CameraButtonProps {
   classes: { buttonContainer: string };
   id: string;
+  goBack: number;
   label?: string;
   photoUri?: string;
   preservedState?: {},
 }
 
 function CameraButton(props: CameraButtonProps) {
-  const { classes, photoUri, preservedState } = props;
+  const { classes, photoUri, preservedState, goBack } = props;
   return (
     <div>
       <InputLabel htmlFor={props.id}>{props.label}</InputLabel>
       <MaterialButton
-        onClick={() => navigateToCamera({preservedState} || {})}
+        onClick={() => navigateToCamera({preservedState} || {}, goBack)}
         className={classes.buttonContainer}
         variant="contained"
         color="primary"

--- a/src/components/CameraButton.tsx
+++ b/src/components/CameraButton.tsx
@@ -1,0 +1,56 @@
+import { Button as MaterialButton, InputLabel, Theme, Typography, withStyles } from '@material-ui/core';
+import { createStyles } from '@material-ui/core/styles';
+import PhotoLibraryIcon from '@material-ui/icons/PhotoLibrary';
+import React from 'react';
+import { navigateToCamera } from '../lib/utils/cameraUtils';
+
+const styles = (theme: Theme) =>
+  createStyles({
+    buttonContainer: {
+      backgroundColor: '#F7F9FC',
+      minHeight: 130,
+      border: `3.5px dashed ${theme.palette.divider}`,
+      radius: '6px',
+      padding: 0,
+      width: '100%',
+    },
+  });
+
+interface CameraButtonProps {
+  classes: { buttonContainer: string };
+  id: string;
+  label?: string;
+  photoUri?: string;
+  preservedState?: {},
+}
+
+function CameraButton(props: CameraButtonProps) {
+  const { classes, photoUri, preservedState } = props;
+  return (
+    <div>
+      <InputLabel htmlFor={props.id}>{props.label}</InputLabel>
+      <MaterialButton
+        onClick={() => navigateToCamera({preservedState} || {})}
+        className={classes.buttonContainer}
+        variant="contained"
+        color="primary"
+        disableElevation={true}
+      >
+        {photoUri ? (
+          <img style={{ width: '100%' }} src={photoUri} />
+        ) : (
+          <div>
+            <Typography color="primary">
+              <PhotoLibraryIcon />
+            </Typography>
+            <Typography variant="h2" color="primary">
+              Add Photo
+            </Typography>
+          </div>
+        )}
+      </MaterialButton>
+    </div>
+  );
+}
+
+export default withStyles(styles)(CameraButton);

--- a/src/components/TextField.tsx
+++ b/src/components/TextField.tsx
@@ -36,7 +36,7 @@ function Field(props: TextFieldProps) {
         InputProps={{ style: { fontSize: 14 }, disableUnderline: true, autoComplete: 'off' }}
         InputLabelProps={{ shrink: true }}
         color={props.primary ? 'primary' : undefined}
-        value={props.value ? props.value : undefined}
+        value={props.value ? props.value : ''}
         onChange={props.onChange}
       />
     </div>

--- a/src/lib/utils/cameraUtils.ts
+++ b/src/lib/utils/cameraUtils.ts
@@ -5,6 +5,6 @@ import { history } from '../redux/store';
 // and it will be passed back to the original screen after the Camera workflow finishes
 // goBack tracks the number of layers in the history stack needed to go back
 export function navigateToCamera(preservedState: object, goBack?: number) {
-    const returnLink = history.location.pathname;
-    history.push('/camera', { ...preservedState, returnLink, goBack});
+  const returnLink = history.location.pathname;
+  history.replace('/camera', { ...preservedState, returnLink, goBack });
 }

--- a/src/lib/utils/cameraUtils.ts
+++ b/src/lib/utils/cameraUtils.ts
@@ -3,7 +3,8 @@ import { history } from '../redux/store';
 // Use function to navigate to camera screen.
 // Pass all state and props that need to be saved into preservedState
 // and it will be passed back to the original screen after the Camera workflow finishes
-export function navigateToCamera(preservedState: object) {
+// goBack tracks the number of layers in the history stack needed to go back
+export function navigateToCamera(preservedState: object, goBack?: number) {
     const returnLink = history.location.pathname;
-    history.push('/camera', { ...preservedState, returnLink });
+    history.push('/camera', { ...preservedState, returnLink, goBack});
 }

--- a/src/screens/Camera/Camera.tsx
+++ b/src/screens/Camera/Camera.tsx
@@ -8,6 +8,7 @@ import BaseScreen from '../../components/BaseComponents/BaseScreen';
 export interface PreservedCameraState {
     preservedState: object;
     returnLink: string;
+    goBack: number;
 }
 
 // TODO: @julianrkung Styling for camera once deployment occurs and you can access on phone
@@ -31,11 +32,11 @@ function CameraScreen(props: CameraProps) {
         history.replace('home');
     }
 
-    const { preservedState, returnLink } = props.location.state;
+    const { preservedState, returnLink, goBack } = props.location.state;
 
     // We navigate to a new screen and pass all state
     const onTakePhoto = (photoUri: string) => {
-        history.push('/camera/preview', { preservedState, returnLink, photoUri })
+        history.push('/camera/preview', { preservedState, returnLink, photoUri, goBack: goBack - 1 })
     }
 
     const onCameraError = (error: Error) => {

--- a/src/screens/Camera/Camera.tsx
+++ b/src/screens/Camera/Camera.tsx
@@ -1,9 +1,9 @@
 import React, { useState } from 'react';
-import { RouteComponentProps, useHistory } from 'react-router-dom';
 import Camera, { FACING_MODES, IMAGE_TYPES } from 'react-html5-camera-photo';
-import BaseScreen from '../../components/BaseComponents/BaseScreen';
 // Preset styles for camera
 import 'react-html5-camera-photo/build/css/index.css';
+import { RouteComponentProps, useHistory } from 'react-router-dom';
+import BaseScreen from '../../components/BaseComponents/BaseScreen';
 
 export interface PreservedCameraState {
     preservedState: object;
@@ -35,7 +35,7 @@ function CameraScreen(props: CameraProps) {
 
     // We navigate to a new screen and pass all state
     const onTakePhoto = (photoUri: string) => {
-        history.push('/camera/preview', { ...preservedState, returnLink, photoUri })
+        history.push('/camera/preview', { preservedState, returnLink, photoUri })
     }
 
     const onCameraError = (error: Error) => {

--- a/src/screens/Camera/Camera.tsx
+++ b/src/screens/Camera/Camera.tsx
@@ -72,7 +72,7 @@ function CameraScreen(props: CameraProps) {
     }
 
     return (
-        <BaseScreen leftIcon="backNav">
+        <BaseScreen leftIcon="backNav" backAction={() => history.replace(returnLink, {...preservedState})}>
             {errorMessage ? renderErrorMessage() : renderCamera()}
         </BaseScreen>
     )

--- a/src/screens/Camera/CameraPreview.tsx
+++ b/src/screens/Camera/CameraPreview.tsx
@@ -1,9 +1,9 @@
+import { createStyles } from '@material-ui/core';
+import { withStyles } from '@material-ui/core/styles';
 import React from 'react';
 import { RouteComponentProps, useHistory } from 'react-router-dom';
 import BaseScreen from '../../components/BaseComponents/BaseScreen';
 import Button from '../../components/Button';
-import { withStyles } from '@material-ui/core/styles';
-import { createStyles } from '@material-ui/core';
 import { PreservedCameraState } from './Camera';
 
 interface CameraPreviewState extends PreservedCameraState {
@@ -22,7 +22,7 @@ const styles = () => createStyles({
 
 function CameraPreview(props: CameraPreviewProps) {
     const history = useHistory();
-    const { preservedState, returnLink, photoUri } = props.location.state;
+    const { preservedState, returnLink, photoUri, goBack } = props.location.state;
 
 
     // If the user enters the camera screen without a returnLink, 
@@ -32,7 +32,7 @@ function CameraPreview(props: CameraPreviewProps) {
     }
 
     const handleConfirm = async () => {
-        history.replace(returnLink, { ...preservedState, photo: photoUri })
+        history.replace(returnLink, { ...preservedState, photo: photoUri, goBack: goBack - 1 })
     }
 
     return (

--- a/src/screens/Inventory/CreatePurchaseRequest.tsx
+++ b/src/screens/Inventory/CreatePurchaseRequest.tsx
@@ -39,6 +39,7 @@ function CreatePurchaseRequest(props: CreatePurchaseRequestProps) {
   const [amountPurchased, setAmountPurchased] = useState(props.location.state?.amountPurchased || 0.0);
   const [amountSpent, setAmountSpent] = useState(props.location.state?.amountSpent || 0.0);
   const [notes, setNotes] = useState(props.location.state?.notes || '');
+  const [submitIsLoading, setSubmitIsLoading] = useState(false);
   const goBack = props.location.state?.goBack || -1;
 
   const photoUri = props.location.state?.photo;
@@ -64,6 +65,7 @@ function CreatePurchaseRequest(props: CreatePurchaseRequestProps) {
   const handleSubmit = (event: React.MouseEvent) => {
     // Prevent page refresh on submit
     event.preventDefault();
+    setSubmitIsLoading(true);
     // Make a deep copy of an empty purchase request record
     const purchaseRequest = JSON.parse(JSON.stringify(EMPTY_PURCHASE_REQUEST));
     purchaseRequest.requesterId = userId;
@@ -111,7 +113,7 @@ function CreatePurchaseRequest(props: CreatePurchaseRequestProps) {
             label="Receipt"
             photoUri={photoUri}
           />
-          <Button label="Submit" onClick={handleSubmit} />
+          <Button loading={submitIsLoading} label="Submit" onClick={handleSubmit} />
         </div>
       </BaseScrollView>
     </BaseScreen>

--- a/src/screens/Inventory/CreatePurchaseRequest.tsx
+++ b/src/screens/Inventory/CreatePurchaseRequest.tsx
@@ -107,7 +107,7 @@ function CreatePurchaseRequest(props: CreatePurchaseRequestProps) {
           <TextField value={notes} label={'Notes (optional)'} id={'notes'} primary={true} onChange={handleNotesInput} />
           <CameraButton
             preservedState={{ amountPurchased, amountSpent, notes }}
-            goBack={goBack}
+            goBack={goBack + 1}
             id="upload-receipt"
             label="Receipt"
             photoUri={photoUri}

--- a/src/screens/Inventory/CreatePurchaseRequest.tsx
+++ b/src/screens/Inventory/CreatePurchaseRequest.tsx
@@ -110,7 +110,7 @@ function CreatePurchaseRequest(props: CreatePurchaseRequestProps) {
             label="Receipt"
             photoUri={photoUri}
           />
-          <Button label="Confirm" onClick={handleSubmit} />
+          <Button label="Submit" onClick={handleSubmit} />
         </div>
       </BaseScrollView>
     </BaseScreen>

--- a/src/screens/Inventory/CreatePurchaseRequest.tsx
+++ b/src/screens/Inventory/CreatePurchaseRequest.tsx
@@ -39,6 +39,7 @@ function CreatePurchaseRequest(props: CreatePurchaseRequestProps) {
   const [amountPurchased, setAmountPurchased] = useState(props.location.state?.amountPurchased || 0.0);
   const [amountSpent, setAmountSpent] = useState(props.location.state?.amountSpent || 0.0);
   const [notes, setNotes] = useState(props.location.state?.notes || '');
+  const goBack = props.location.state?.goBack || -1;
 
   const photoUri = props.location.state?.photo;
 
@@ -76,7 +77,7 @@ function CreatePurchaseRequest(props: CreatePurchaseRequestProps) {
     }
 
     await createPurchaseRequestAndUpdateInventory(purchaseRequest);
-    history.goBack(); // TODO: fix!!
+    history.go(goBack);
   };
 
   return (
@@ -106,6 +107,7 @@ function CreatePurchaseRequest(props: CreatePurchaseRequestProps) {
           <TextField value={notes} label={'Notes (optional)'} id={'notes'} primary={true} onChange={handleNotesInput} />
           <CameraButton
             preservedState={{ amountPurchased, amountSpent, notes }}
+            goBack={goBack}
             id="upload-receipt"
             label="Receipt"
             photoUri={photoUri}

--- a/src/screens/Inventory/CreatePurchaseRequest.tsx
+++ b/src/screens/Inventory/CreatePurchaseRequest.tsx
@@ -77,7 +77,7 @@ function CreatePurchaseRequest(props: CreatePurchaseRequestProps) {
     purchaseRequest.amountSpent = amountSpent;
     purchaseRequest.notes = notes;
     purchaseRequest.inventoryId = inventory.id;
-    // TODO: add image upload
+    purchaseRequest.receipt = [{ url: photoUri }];
 
     await createPurchaseRequestAndUpdateInventory(purchaseRequest);
     history.goBack(); // TODO: fix!!

--- a/src/screens/Inventory/CreatePurchaseRequest.tsx
+++ b/src/screens/Inventory/CreatePurchaseRequest.tsx
@@ -22,16 +22,10 @@ const styles = (theme: Theme) =>
       display: 'flex',
       flexDirection: 'column',
     },
-    cameraButton: {
-      backgroundColor: '#F7F9FC',
-      height: 130,
-      border: `3.5px dashed ${theme.palette.divider}`,
-      radius: '6px',
-    },
   });
 
 interface CreatePurchaseRequestProps extends RouteComponentProps {
-  classes: { content: string; cameraButton: string };
+  classes: { content: string; };
   location: any;
 }
 
@@ -77,7 +71,9 @@ function CreatePurchaseRequest(props: CreatePurchaseRequestProps) {
     purchaseRequest.amountSpent = amountSpent;
     purchaseRequest.notes = notes;
     purchaseRequest.inventoryId = inventory.id;
-    purchaseRequest.receipt = [{ url: photoUri }];
+    if (photoUri) {
+      purchaseRequest.receipt = [{ url: photoUri }];
+    }
 
     await createPurchaseRequestAndUpdateInventory(purchaseRequest);
     history.goBack(); // TODO: fix!!

--- a/src/screens/Inventory/CreatePurchaseRequest.tsx
+++ b/src/screens/Inventory/CreatePurchaseRequest.tsx
@@ -44,7 +44,7 @@ function CreatePurchaseRequest(props: CreatePurchaseRequestProps) {
 
   const [amountPurchased, setAmountPurchased] = useState(props.location.state?.amountPurchased || 0.0);
   const [amountSpent, setAmountSpent] = useState(props.location.state?.amountSpent || 0.0);
-  const [notes, setNotes] = useState(props.location.state?.notes || 0.0);
+  const [notes, setNotes] = useState(props.location.state?.notes || '');
 
   const photoUri = props.location.state?.photo;
 
@@ -100,7 +100,13 @@ function CreatePurchaseRequest(props: CreatePurchaseRequestProps) {
             primary={true}
             onChange={handleAmountPurchasedInput}
           />
-          <TextField value={amountSpent} label={'Amount Spent (ks)'} id={'amount-spent'} primary={true} onChange={handleAmountSpentInput} />
+          <TextField
+            value={amountSpent}
+            label={'Amount Spent (ks)'}
+            id={'amount-spent'}
+            primary={true}
+            onChange={handleAmountSpentInput}
+          />
           <TextField value={notes} label={'Notes (optional)'} id={'notes'} primary={true} onChange={handleNotesInput} />
           <CameraButton
             preservedState={{ amountPurchased, amountSpent, notes }}

--- a/src/screens/Inventory/PurchaseRequest.tsx
+++ b/src/screens/Inventory/PurchaseRequest.tsx
@@ -27,10 +27,16 @@ const styles = (theme: Theme) =>
     section: {
       marginTop: '30px',
     },
+    imageContainer: {
+      border: `3.5px solid ${theme.palette.divider}`,
+      radius: '6px',
+      padding: 0,
+      width: '100%',
+    },
   });
 
 interface PurchaseRequestsProps extends RouteComponentProps {
-  classes: { content: string; section: string };
+  classes: { content: string; section: string, imageContainer: string };
   location: any;
 }
 
@@ -67,10 +73,10 @@ function PurchaseRequest(props: PurchaseRequestsProps) {
           <Typography variant="body1">{`Amount purchased ${purchaseRequest.amountPurchased} ${product.unit}(s)`}</Typography>
           <Typography variant="body1">{`Amount spent ${purchaseRequest.amountSpent} ks`}</Typography>
           <Typography variant="body1">{`Created at ${purchaseRequest.createdAt}`}</Typography>
+          {/* TODO: admins lookup user info by id */}
           <Typography variant="body1">{`Submitted by ${purchaseRequest.requesterId}`}</Typography>
           {purchaseRequest.notes && <Typography variant="body1">{`Notes: ${purchaseRequest.notes}`}</Typography>}
-          {/* TODO: admins lookup user info by id */}
-          {/* TODO: Add image */}
+          {purchaseRequest.receipt && <img className={classes.imageContainer} src={purchaseRequest.receipt[0].url} alt="receipt"/> }
           {purchaseRequest.status == PurchaseRequestStatus.PENDING && (
             <div>
               <Button onClick={() => handleSubmit(purchaseRequest, true)} label={'Approve'} />

--- a/src/screens/Inventory/PurchaseRequest.tsx
+++ b/src/screens/Inventory/PurchaseRequest.tsx
@@ -65,7 +65,7 @@ function PurchaseRequest(props: PurchaseRequestsProps) {
   };
 
   return (
-    <BaseScreen leftIcon="backNav">
+    <BaseScreen title="Inventory Receipt" leftIcon="backNav">
       <BaseScrollView>
         <div className={classes.content}>
           <Typography variant="h3">{`Purchase Request for ${product.name}`}</Typography>


### PR DESCRIPTION
[//]: # "These comments are meant for your reference. They are invisible and don't need to be deleted!"

# What's new in this PR
This PR integrates the camera functionality established in #53 with the purchase request creation workflow. Users can take pictures and upload receipts along with their purchase requests.

Note: I ended up separating out CameraButton into a dedicated component since it's repeated several times throughout the app.

## How to review
On the backend, run the latest version of `annie/purchase-request-camera` to test.

**Help fix Annie's bug**
UPDATE: fixed with something in this https://stackoverflow.com/questions/50575215/access-react-router-history-stack
I haven't been able to figure out a smooth navigation workflow with the camera and camera/preview screens. After submitting the purchase request, I used to have it just do `history.goBack()` but now that goes back to one of the camera screens. I've tried:
- a series of `replace`'s (instead of the `push` actions happening in the camera flow currently) but that also makes things messy within the actual camera flow (e.g. if everything is replace instead of push, if you go back on the preview screen, you're kicked all the way back out into the inventory item screen)
- using `history.go(-3)` to go back 3 layers (to bypass the camera screens) but that doesn't work if the user goes through the camera flow multiple times (i.e. to re-take a picture)


**Make a purchase request**
- Go through the whole purchase request creation flow and upload a picture!
  - Make sure the image is uploaded in Airtable

## Relevant Links

### Online sources
https://reactrouter.com/web/api/history

### Related PRs
Integrates work from #53 
Companion backend PR: https://github.com/calblueprint/meepanyar-node/pull/21

[//]: # "Optional - related PRs you're waiting on/ PRs that will conflict, etc; if this is a refactor, feel free to add PRs that previously modified this code"

## Next steps
- Update styling on the purchase request page
- Look into storage implications of keeping the photo as a URI on the frontend, since it could be a potential bottleneck down the road (see [comment](https://github.com/calblueprint/meepanyar/pull/69#pullrequestreview-627571118))

### Screenshots
![image](https://user-images.githubusercontent.com/21160510/113491925-22c99a00-9489-11eb-87d9-6cb2e083cd29.png)
![localhost_3000_inventory(Galaxy S5)](https://user-images.githubusercontent.com/21160510/113491900-f57cec00-9488-11eb-9bfa-5ad3ae801411.png)

CC: @julianrkung

[//]: # 'This tags Julian as a default. Feel free to change, or add on anyone who you should be in on the conversation.'