### PR TITLE
Fix blank text field bug

### DIFF
--- a/src/components/TextField.tsx
+++ b/src/components/TextField.tsx
@@ -36,7 +36,7 @@ function Field(props: TextFieldProps) {
         InputProps={{ style: { fontSize: 14 }, disableUnderline: true, autoComplete: 'off' }}
         InputLabelProps={{ shrink: true }}
         color={props.primary ? 'primary' : undefined}
-        value={props.value ? props.value : ''}
+        inputProps={props.value !== undefined ? { value: props.value || '' } : { defaultValue: '' }}
         onChange={props.onChange}
       />
     </div>

--- a/src/components/TextField.tsx
+++ b/src/components/TextField.tsx
@@ -36,7 +36,7 @@ function Field(props: TextFieldProps) {
         InputProps={{ style: { fontSize: 14 }, disableUnderline: true, autoComplete: 'off' }}
         InputLabelProps={{ shrink: true }}
         color={props.primary ? 'primary' : undefined}
-        inputProps={props.value !== undefined ? { value: props.value || '' } : { defaultValue: '' }}
+        value={props.value || undefined}
         onChange={props.onChange}
       />
     </div>


### PR DESCRIPTION
[//]: # "These comments are meant for your reference. They are invisible and don't need to be deleted!"

# What's new in this PR
A quick one-line fix for a bug introduced in #69 where default value on textfields was set to `''`making them un-editable for uncontrolled TextFields that don't rely on the optional `value` prop. Now, all `TextFields` should have normal behavior.

Note: this is a temporary fix. We still have this error with controlled/uncontrolled components (for both TextField and Checkbox) that we will handle in a future PR.
![image](https://user-images.githubusercontent.com/21160510/113627959-1116fc80-9619-11eb-905e-0584e599b743.png)


## How to review
- Make sure you can type into the Inventory Update text field
- Make sure you can use all the text fields in Edit Customer

[//]: # 'The order in which to review files and what to expect when testing locally'

## Relevant Links

### Online sources
https://material-ui.com/components/text-fields/#uncontrolled-vs-controlled

[//]: # 'Optional - copy links to any tutorial or documentation that was useful to you when working on this PR'

### Related PRs
Fixing a bug introduced in #69 

## Next steps
- Convert all text fields to controlled components.

### Screenshots
n/a

CC: @julianrkung

[//]: # 'This tags Julian as a default. Feel free to change, or add on anyone who you should be in on the conversation.'