### PR TITLE
[Schema Change] Renamed Min Units column to Free Units in Tariff Plan

### DIFF
--- a/src/lib/airtable/interface.ts
+++ b/src/lib/airtable/interface.ts
@@ -54,7 +54,7 @@ export interface TariffPlanRecord {
   name: string;
   fixedTariff: number;
   tariffByUnit: number;
-  minUnits: number;
+  freeUnits: number;
 }
 
 export interface CustomerRecord {

--- a/src/lib/airtable/interface.ts
+++ b/src/lib/airtable/interface.ts
@@ -71,6 +71,7 @@ export interface CustomerRecord {
   customerUpdates: CustomerUpdateRecord[];
   totalAmountBilledfromInvoices: number;
   totalAmountPaidfromPayments: number;
+  startingMeterReading: number;
 }
 
 export interface CustomerUpdateRecord {

--- a/src/lib/airtable/schema.js
+++ b/src/lib/airtable/schema.js
@@ -82,6 +82,7 @@ export const Columns = {
 		id: {name:`ID`, type:`formula`},
 		meterType: {name:`Meter Type`, type:`select`},
 		customerNumber: {name:`Customer Number`, type:`number`},
+		startingMeterReading: {name:`Starting Meter Reading`, type:`number`},
 	},
 	"Customer Updates": {
 		dateUpdated: {name:`Date Updated`, type:`date`},

--- a/src/lib/airtable/schema.js
+++ b/src/lib/airtable/schema.js
@@ -61,7 +61,7 @@ export const Columns = {
 		name: {name:`Name`, type:`text`},
 		fixedTariff: {name:`Fixed Tariff`, type:`number`},
 		tariffByUnit: {name:`Tariff By Unit`, type:`number`},
-		minUnits: {name:`Min Units`, type:`number`},
+		freeUnits: {name:`Free Units`, type:`number`},
 		customerIds: {name:`Customer`, type:`foreignKey-many`},
 		siteIds: {name:`Sites`, type:`foreignKey-many`},
 		id: {name:`ID`, type:`formula`},

--- a/src/lib/redux/customerDataSlice.ts
+++ b/src/lib/redux/customerDataSlice.ts
@@ -68,6 +68,7 @@ export const EMPTY_CUSTOMER: CustomerRecord = {
     customerUpdates: [],
     totalAmountBilledfromInvoices: 0,
     totalAmountPaidfromPayments: 0,
+    startingMeterReading: 0,
 }
 
 export const EMPTY_PAYMENT: PaymentRecord = {

--- a/src/screens/Customers/CustomerProfile.tsx
+++ b/src/screens/Customers/CustomerProfile.tsx
@@ -69,12 +69,12 @@ function CustomerProfile(props: CustomerProps) {
 
   const fixedTariff = customerTariff ? customerTariff?.fixedTariff : UNDEFINED_AMOUNT;
   const unitTariff = customerTariff ? customerTariff?.tariffByUnit : UNDEFINED_AMOUNT;
-  const minUnits = customerTariff ? customerTariff?.minUnits : UNDEFINED_AMOUNT;
+  const freeUnits = customerTariff ? customerTariff?.freeUnits : UNDEFINED_AMOUNT;
 
   const tariffInfo: CardPropsInfo[] = [
     { number: fixedTariff.toString(), label: 'Fixed Tariff', unit: 'MMK' },
     { number: unitTariff.toString(), label: 'Unit Tariff', unit: 'MMK' },
-    { number: minUnits.toString(), label: 'Minimum Units Used', unit: '' },
+    { number: freeUnits.toString(), label: 'Free Units', unit: '' },
   ]
 
   const currReading: MeterReadingRecord | undefined = getCurrentReading(customer);


### PR DESCRIPTION
[//]: # "These comments are meant for your reference. They are invisible and don't need to be deleted!"

# What's new in this PR
Tariff Plan's "Min Units" column was renamed to "Free Units". This PR runs the schema generator. There were no patch conflicts with this change.

Also adding a column "Starting Meter Reading" to customer column to keep track of meter reading to start from for customers

I temporarily changed the "Free Units" column back to "Min Units" to not block anyone else. When merging this PR, "Min Units" column should be changed back to "Free Units"


[//]: # "Describe what's new in this PR in a few lines. A description and bullet points for specifics will suffice."

## How to review
Look over the PR and check if the appropriate things were changed or if there's anything missing

[//]: # 'The order in which to review files and what to expect when testing locally'

## Relevant Links

### Online sources

[//]: # 'Optional - copy links to any tutorial or documentation that was useful to you when working on this PR'

### Related PRs

[//]: # "Optional - related PRs you're waiting on/ PRs that will conflict, etc; if this is a refactor, feel free to add PRs that previously modified this code"

## Next steps

[//]: # "What's NOT in this PR, doesn't work yet, and/or still needs to be done"

### Screenshots

[//]: # "Add screenshots of expected behavior - GIFs if you're feeling fancy!"

CC: @julianrkung

[//]: # 'This tags Julian as a default. Feel free to change, or add on anyone who you should be in on the conversation.'