### PR TITLE
Preserve '0' input for Purchase Request amount spent

### DIFF
--- a/src/screens/Inventory/CreatePurchaseRequest.tsx
+++ b/src/screens/Inventory/CreatePurchaseRequest.tsx
@@ -29,7 +29,10 @@ const styles = (theme: Theme) =>
   });
 
 const validationSchema = yup.object({
-  amountPurchased: yup.number().min(0, 'Please enter a valid amount').required('Please enter an amount'),
+  amountPurchased: yup
+    .number()
+    .positive('Please enter a valid amount greater than 0')
+    .required('Please enter an amount'),
   amountSpent: yup.number().min(0, 'Please enter a valid amount').required('Please enter an amount'),
   notes: yup.string(),
   receipt: yup.string().required('Please upload a receipt image'),
@@ -54,8 +57,8 @@ function CreatePurchaseRequest(props: CreatePurchaseRequestProps) {
 
   const formik = useFormik({
     initialValues: {
-      amountPurchased: (props.location.state?.amountPurchased as string) || '',
-      amountSpent: (props.location.state?.amountSpent as string) || '',
+      amountPurchased: String(props.location.state?.amountPurchased) || '',
+      amountSpent: String(props.location.state?.amountSpent) || '',
       notes: (props.location.state?.notes as string) || '',
       receipt: (props.location.state?.photo as string) || '',
     },
@@ -126,7 +129,7 @@ function CreatePurchaseRequest(props: CreatePurchaseRequestProps) {
             helperText={formik.touched.amountSpent && formik.errors.amountSpent}
           />
           <TextField
-            placeholder="Enter Notes..."
+            placeholder="Enter notes..."
             label={'Notes'}
             id={'notes'}
             value={formik.values.notes}


### PR DESCRIPTION
[//]: # "These comments are meant for your reference. They are invisible and don't need to be deleted!"

# What's new in this PR

This PR resolves #115 where if users entered '0' in the Create Purchase Request flow, their inputs would disappear after returning from the camera flow. This also changes the minimum "amount purchased" from 0 to restrict to non-zero positive numbers.

The issue was resolved by changing `props.location.state?.amountPurchased as string` to `String(props.location.state?.amountPurchased)`. For some reason `0 as string` which converts it to `''`, whereas `String('0')` keeps it as `'0'`.

## How to review
Test this flow (adapted from the issue -- shoutout to Fred for the helpful level of detail 👏🏻 )
1. Go to the inventory purchase page
2. Enter 0 for Amount Spent
3. Take a picture
4. Upon return, the 0 entered in the Amount Spent field **should not disappear**
5. Click Submit
6. See the Recent Updates for the inventory item
7. Click the purchase record
8. The Amount Spent **should not be** an empty field

## Relevant Links

### Online sources
n/a

### Related PRs
n/a

## Next steps
n/a

### Screenshots
<img src="https://user-images.githubusercontent.com/21160510/115664044-36cd2280-a2f6-11eb-9e12-5195e49409e5.png" width="40%"><img src="https://user-images.githubusercontent.com/21160510/115664096-42b8e480-a2f6-11eb-9ce7-130a2fa2dada.png" width="40%">


CC: @julianrkung

[//]: # 'This tags Julian as a default. Feel free to change, or add on anyone who you should be in on the conversation.'