### PR TITLE
Only Admins Can Edit Profile Pages

### DIFF
--- a/src/screens/Profile/EditSiteInformation.tsx
+++ b/src/screens/Profile/EditSiteInformation.tsx
@@ -7,12 +7,14 @@ import { useHistory } from 'react-router';
 import { selectCurrentSiteInformation, updateSiteInRedux } from '../../lib/redux/siteData';
 import Button from '../../components/Button';
 import { updateSite } from '../../lib/airtable/request';
+import { selectCurrentUserIsAdmin } from '../../lib/redux/userData';
 
 
 function EditSiteInformation() {
     const history = useHistory();
 
     const currentSite = useSelector(selectCurrentSiteInformation);
+    const currentUserIsAdmin = useSelector(selectCurrentUserIsAdmin);
     const currentSiteName = currentSite ? currentSite.name : 'No Site';
 
     const [newSiteName, setNewSiteName] = useState(currentSiteName);
@@ -57,15 +59,15 @@ function EditSiteInformation() {
                 <ListItemWrapper
                     leftText='Site Name'
                     rightText={currentSiteName}
-                    editable
                     dense
                     editValue={newSiteName}
+                    editable={currentUserIsAdmin}
                     onEditChange={handleSiteNameInput}
                     editInputId={'edit-site-name'}
                     editPlaceholder={'Input Site Name'}
                 />
             </List>
-            <Button fullWidth label={'SAVE'} onClick={handleSubmit} loading={loading} />
+            {currentUserIsAdmin && <Button fullWidth label={'Save'} onClick={handleSubmit} loading={loading} />}
             {errorMessage ? <Typography color='error' align='center'> {errorMessage} </Typography> : null}
         </BaseScreen>
     );

--- a/src/screens/Profile/EditTariffPlanInformation.tsx
+++ b/src/screens/Profile/EditTariffPlanInformation.tsx
@@ -7,6 +7,8 @@ import { TariffPlanRecord } from '../../lib/airtable/interface';
 import Button from '../../components/Button';
 import { updateTariffPlan } from '../../lib/airtable/request';
 import { updateTariffPlanInRedux } from '../../lib/redux/siteData';
+import { useSelector } from 'react-redux';
+import { selectCurrentUserIsAdmin } from '../../lib/redux/userData';
 
 
 type EditTarifPlanInformationProps = RouteComponentProps<{}, {}, { tariffPlan: TariffPlanRecord }>;
@@ -15,6 +17,7 @@ function EditTariffPlanInformation(props: EditTarifPlanInformationProps) {
     const { tariffPlan } = props.location.state;
     const history = useHistory();
 
+    const currentUserIsAdmin = useSelector(selectCurrentUserIsAdmin);
     const [newFixedTariff, setNewFixedTariff] = useState(tariffPlan.fixedTariff.toString() || '');
     const [newTariffByUnit, setNewTariffByUnit] = useState(tariffPlan.tariffByUnit.toString() || '');
     const [newFreeUnits, setNewFreeUnits] = useState(tariffPlan.freeUnits.toString() || '');
@@ -34,7 +37,7 @@ function EditTariffPlanInformation(props: EditTarifPlanInformationProps) {
     }
 
     const handleSubmit = async (event: React.MouseEvent) => {
-        
+
         const fixedTariff = parseFloat(newFixedTariff);
         const tariffByUnit = parseFloat(newTariffByUnit);
         const freeUnits = parseFloat(newFreeUnits);
@@ -61,7 +64,7 @@ function EditTariffPlanInformation(props: EditTarifPlanInformationProps) {
         } finally {
             // We naively update the tariff plan in redux and do proper authentication on the backend
             // to make sure only admins can successfully change tariff plans
-            updateTariffPlanInRedux({id: tariffPlan.id, ...newTariffPlanProperties});
+            updateTariffPlanInRedux({ id: tariffPlan.id, ...newTariffPlanProperties });
             history.goBack()
         }
     }
@@ -72,7 +75,7 @@ function EditTariffPlanInformation(props: EditTarifPlanInformationProps) {
                 <ListItemWrapper
                     leftText='Fixed Payment'
                     rightText={newFixedTariff}
-                    editable
+                    editable={currentUserIsAdmin}
                     dense
                     editValue={newFixedTariff}
                     onEditChange={handleNewFixedTariffInput}
@@ -85,7 +88,7 @@ function EditTariffPlanInformation(props: EditTarifPlanInformationProps) {
                 <ListItemWrapper
                     leftText='Per Unit Payment'
                     rightText={newTariffByUnit}
-                    editable
+                    editable={currentUserIsAdmin}
                     dense
                     editValue={newTariffByUnit}
                     onEditChange={handleNewTariffByUnitInput}
@@ -98,7 +101,7 @@ function EditTariffPlanInformation(props: EditTarifPlanInformationProps) {
                 <ListItemWrapper
                     leftText='Free Units'
                     rightText={newFreeUnits}
-                    editable
+                    editable={currentUserIsAdmin}
                     dense
                     editValue={newFreeUnits}
                     onEditChange={handleNewFreeUnitsInput}
@@ -109,7 +112,7 @@ function EditTariffPlanInformation(props: EditTarifPlanInformationProps) {
                     editPlaceholder={'e.g. 5'}
                 />
             </List>
-            <Button fullWidth label={'SAVE'} onClick={handleSubmit} loading={loading} />
+            {currentUserIsAdmin && <Button fullWidth label={'Save'} onClick={handleSubmit} loading={loading} />}
             {errorMessage ? <Typography color='error' align='center'> {errorMessage} </Typography> : null}
         </BaseScreen>
     );

--- a/src/screens/Profile/EditUserInformation.tsx
+++ b/src/screens/Profile/EditUserInformation.tsx
@@ -5,7 +5,8 @@ import { RouteComponentProps, useHistory } from 'react-router';
 import { UserRecord } from '../../lib/airtable/interface';
 import Button from '../../components/Button';
 import { updateUser } from '../../lib/airtable/request';
-import { updateUserInRedux } from '../../lib/redux/userData';
+import { selectCurrentUserIsAdmin, updateUserInRedux } from '../../lib/redux/userData';
+import { useSelector } from 'react-redux';
 
 type EditTarifPlanInformationProps = RouteComponentProps<{}, {}, { user: UserRecord }>;
 
@@ -13,6 +14,7 @@ function EditUserInformation(props: EditTarifPlanInformationProps) {
     const { user } = props.location.state;
 
     const history = useHistory();
+    const currentUserIsAdmin = useSelector(selectCurrentUserIsAdmin);
     const [newIsAdmin, setNewIsAdmin] = useState(user.admin || false);
     const [loading, setLoading] = useState(false);
 
@@ -30,7 +32,7 @@ function EditUserInformation(props: EditTarifPlanInformationProps) {
         } finally {
             // We naively update the user in redux and do proper authentication on the backend
             // to make sure only admins can successfully make other users admins
-            updateUserInRedux({id: user.id, admin: newIsAdmin});
+            updateUserInRedux({ id: user.id, admin: newIsAdmin });
             history.goBack()
         }
     }
@@ -44,11 +46,19 @@ function EditUserInformation(props: EditTarifPlanInformationProps) {
                         primaryTypographyProps={{ color: 'textPrimary', variant: 'body1' }}
                     />
                     <ListItemSecondaryAction>
-                        <Switch color='primary' edge='end' id='edit-active-status' checked={newIsAdmin} onChange={() => setNewIsAdmin(!newIsAdmin)} />
+                        <Switch
+                            color='primary'
+                            edge='end'
+                            id='edit-active-status'
+                            checked={newIsAdmin}
+                            onChange={() => setNewIsAdmin(!newIsAdmin)}
+                            disabled={!currentUserIsAdmin}
+                        />
                     </ListItemSecondaryAction>
                 </ListItem>
             </List>
-            <Button fullWidth label={'SAVE'} onClick={handleSubmit} loading={loading} />
+
+            {currentUserIsAdmin && <Button fullWidth label={'Save'} onClick={handleSubmit} loading={loading} />}
         </BaseScreen>
     );
 }

--- a/src/screens/Profile/TariffPlans.tsx
+++ b/src/screens/Profile/TariffPlans.tsx
@@ -8,6 +8,7 @@ import { selectAllTariffPlansArray } from '../../lib/redux/siteDataSlice';
 import { TariffPlanRecord } from '../../lib/airtable/interface';
 import { useHistory } from 'react-router';
 import ArrowForwardIosIcon from '@material-ui/icons/ArrowForwardIos';
+import BaseScrollView from '../../components/BaseComponents/BaseScrollView';
 
 const styles = makeStyles((theme: Theme) =>
   createStyles({
@@ -24,24 +25,37 @@ function TariffPlans() {
   // TODO: Add customer looking for tariff plans and render tariff plans without customers separately
   const tariffPlans: TariffPlanRecord[] = useSelector(selectAllTariffPlansArray) || [];
 
+  const usedTariffPlans = tariffPlans.filter((tariffPlan: TariffPlanRecord) => tariffPlan.numberOfCustomers > 0);
+  const unusedTariffPlans = tariffPlans.filter((tariffPlan: TariffPlanRecord) => tariffPlan.numberOfCustomers === 0);
+
   return (
     <BaseScreen title="Tariff Plans" leftIcon="backNav">
-      <List style={{ padding: 0 }}>
-        <ListItem disableGutters>
-          <ListItemText primary='Used' primaryTypographyProps={{ color: 'inherit' }} className={classes.header} />
-        </ListItem>
-        {tariffPlans.map((tariffPlan: TariffPlanRecord) =>
-          <TariffPlanCard
-            key={tariffPlan.id}
-            tariffPlan={tariffPlan}
-            handleTariffPlanClick={() => history.push(`${history.location.pathname}/tariff-plan`, { tariffPlan })}
-            rightIcon={<ArrowForwardIosIcon fontSize='small' />}
-          />)
-        }
-        <ListItem disableGutters>
-          <ListItemText primary='Unused' className={classes.header} />
-        </ListItem>
-      </List>
+      <BaseScrollView>
+        <List style={{ padding: 0 }}>
+          <ListItem disableGutters>
+            <ListItemText primary='Used' primaryTypographyProps={{ color: 'inherit' }} className={classes.header} />
+          </ListItem>
+          {usedTariffPlans.map((tariffPlan: TariffPlanRecord) =>
+            <TariffPlanCard
+              key={tariffPlan.id}
+              tariffPlan={tariffPlan}
+              handleTariffPlanClick={() => history.push(`${history.location.pathname}/tariff-plan`, { tariffPlan })}
+              rightIcon={<ArrowForwardIosIcon fontSize='small' />}
+            />)
+          }
+          <ListItem disableGutters>
+            <ListItemText primary='Unused' className={classes.header} />
+          </ListItem>
+          {unusedTariffPlans.map((tariffPlan: TariffPlanRecord) =>
+            <TariffPlanCard
+              key={tariffPlan.id}
+              tariffPlan={tariffPlan}
+              handleTariffPlanClick={() => history.push(`${history.location.pathname}/tariff-plan`, { tariffPlan })}
+              rightIcon={<ArrowForwardIosIcon fontSize='small' />}
+            />)
+          }
+        </List>
+      </BaseScrollView>
     </BaseScreen>
   );
 }


### PR DESCRIPTION
[//]: # "These comments are meant for your reference. They are invisible and don't need to be deleted!"

# What's new in this PR
This PR allows only admins to edit the profile pages. Nonadmins should see a ReadOnly version of the same pages that an admin can see.

This PR also populated the "Unused Tariff Plans" portion fo the "Tariff Plans" screen.

[//]: # "Describe what's new in this PR in a few lines. A description and bullet points for specifics will suffice."

## How to review
### As a nonadmin
1. Log in as a nonadmin. The typical credentials are `username: nonadmin ; password: test`
2. Go to the profile page and click around all the editable pages and make sure nothing is editable / submitable (you can only view)

### As an admin
1. Log in as an admin. The typical credentials are `username: admin ; password: test`
2. Go to the profile page and click around that pages are editable and submittable

[//]: # 'The order in which to review files and what to expect when testing locally'

## Relevant Links

### Online sources

[//]: # 'Optional - copy links to any tutorial or documentation that was useful to you when working on this PR'

### Related PRs

[//]: # "Optional - related PRs you're waiting on/ PRs that will conflict, etc; if this is a refactor, feel free to add PRs that previously modified this code"

## Next steps

[//]: # "What's NOT in this PR, doesn't work yet, and/or still needs to be done"

### Screenshots

[//]: # "Add screenshots of expected behavior - GIFs if you're feeling fancy!"

CC: @julianrkung

[//]: # 'This tags Julian as a default. Feel free to change, or add on anyone who you should be in on the conversation.'