### PR TITLE
[Inventory] Edit purchase request review status

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -37,6 +37,7 @@ import EditTariffPlanInformation from './screens/Profile/EditTariffPlanInformati
 import AddInventory from './screens/Inventory/AddInventory';
 import CreateInventoryUpdate from './screens/Inventory/CreateInventoryUpdate';
 import CreatePurchaseRequest from './screens/Inventory/CreatePurchaseRequest';
+import EditPurchaseRequest from './screens/Inventory/EditPurchaseRequest';
 import InventoryMain from './screens/Inventory/InventoryMain';
 import InventoryProfile from './screens/Inventory/InventoryProfile';
 import PurchaseRequest from './screens/Inventory/PurchaseRequest';
@@ -84,7 +85,8 @@ function App() {
       <AuthenticatedRoute path="/inventory/item" component={InventoryProfile} /> 
       <AuthenticatedRoute path="/inventory/purchase-requests" component={PurchaseRequestsMain} exact/> 
       <AuthenticatedRoute path="/inventory/purchase-requests/create" component={CreatePurchaseRequest} /> 
-      <AuthenticatedRoute path="/inventory/purchase-requests/purchase-request" component={PurchaseRequest} /> 
+      <AuthenticatedRoute path="/inventory/purchase-requests/purchase-request" component={PurchaseRequest} exact /> 
+      <AuthenticatedRoute path="/inventory/purchase-requests/purchase-request/edit" component={EditPurchaseRequest} /> 
       <AuthenticatedRoute path="/inventory/updates/create" component={CreateInventoryUpdate} /> 
 
       <AuthenticatedRoute path="/maintenance" component={Maintenance} />

--- a/src/lib/redux/inventoryData.ts
+++ b/src/lib/redux/inventoryData.ts
@@ -17,8 +17,10 @@ import {
   selectAllCurrentSitePurchaseRequestsArray,
   selectAllInventoryUpdatesArray,
   selectCurrentSiteInventoryById,
+  selectCurrentSitePurchaseRequestById,
   selectProductById,
   setCurrInventoryId,
+  setCurrPurchaseRequestId,
   updateInventoryQuantity,
   updatePurchaseRequest
 } from './inventoryDataSlice';
@@ -52,6 +54,8 @@ export const selectProductByInventoryId = createSelector(getInventoryId, store.g
 
 // Custom selectors for current inventory and product
 export const selectCurrentInventoryId = (state: RootState): string => state.inventoryData.currentInventoryId;
+export const selectCurrentPurchaseRequestId = (state: RootState): string =>
+  state.inventoryData.currentPurchaseRequestId;
 
 export const selectCurrentInventory = createSelector(
   selectCurrentInventoryId,
@@ -63,6 +67,12 @@ export const selectCurrentInventoryProduct = createSelector(
   selectCurrentInventoryId,
   store.getState,
   (inventoryId, state) => selectProductByInventoryId(state, inventoryId),
+);
+
+export const selectCurrentPurchaseRequest = createSelector(
+  selectCurrentPurchaseRequestId,
+  store.getState,
+  (currentPurchaseRequestId, state) => selectCurrentSitePurchaseRequestById(state, currentPurchaseRequestId),
 );
 
 export const selectPendingPurchaseRequestCount = createSelector(
@@ -131,6 +141,10 @@ export const getInventoryCurrentQuantity = (inventoryId: string): number => {
 
 export const setCurrentInventoryIdInRedux = (inventoryId: string): void => {
   store.dispatch(setCurrInventoryId(inventoryId));
+};
+
+export const setCurrentPurchaseRequestIdInRedux = (purchaseRequestId: string): void => {
+  store.dispatch(setCurrPurchaseRequestId(purchaseRequestId));
 };
 
 export const addProductToRedux = (product: ProductRecord): void => {

--- a/src/lib/redux/inventoryDataSlice.ts
+++ b/src/lib/redux/inventoryDataSlice.ts
@@ -75,12 +75,14 @@ interface inventoryDataSliceState {
   products: EntityState<ProductRecord>;
   sitesInventory: Record<SiteIdString, SiteInventoryData>;
   currentInventoryId: string;
+  currentPurchaseRequestId: string;
 }
 
 const initialState: inventoryDataSliceState = {
   products: productsAdapter.getInitialState(),
   sitesInventory: {},
   currentInventoryId: '',
+  currentPurchaseRequestId: '',
 };
 
 export const EMPTY_INVENTORY: InventoryRecord = {
@@ -182,6 +184,9 @@ const inventoryDataSlice = createSlice({
     setCurrInventoryId(state, action) {
       state.currentInventoryId = action.payload;
     },
+    setCurrPurchaseRequestId(state, action) {
+      state.currentPurchaseRequestId = action.payload;
+    },
     addProduct(state, action) {
       productsAdapter.addOne(state.products, action.payload);
     },
@@ -190,6 +195,7 @@ const inventoryDataSlice = createSlice({
     // If the site changes, reset currentInventoryId
     [setCurrentSiteId.type]: (state, action) => {
       state.currentInventoryId = initialState.currentInventoryId;
+      state.currentPurchaseRequestId = initialState.currentPurchaseRequestId;
     },
   },
 });
@@ -202,6 +208,7 @@ export const {
   addInventoryUpdate,
   updateInventoryQuantity,
   setCurrInventoryId,
+  setCurrPurchaseRequestId,
   addProduct,
 } = inventoryDataSlice.actions;
 export default inventoryDataSlice.reducer;

--- a/src/screens/Inventory/EditPurchaseRequest.tsx
+++ b/src/screens/Inventory/EditPurchaseRequest.tsx
@@ -1,0 +1,80 @@
+import {
+    createStyles,
+    IconButton,
+    List,
+    ListItem,
+    ListItemSecondaryAction,
+    ListItemText,
+    Theme,
+    withStyles
+} from '@material-ui/core';
+import React, { useState } from 'react';
+import { useSelector } from 'react-redux';
+import { Redirect, RouteComponentProps, useHistory } from 'react-router-dom';
+import BaseScreen from '../../components/BaseComponents/BaseScreen';
+import Button from '../../components/Button';
+import { PurchaseRequestRecord } from '../../lib/airtable/interface';
+import { selectCurrentPurchaseRequest } from '../../lib/redux/inventoryData';
+import { EMPTY_PURCHASE_REQUEST, PurchaseRequestStatus } from '../../lib/redux/inventoryDataSlice';
+import { selectCurrentUserId, selectCurrentUserIsAdmin } from '../../lib/redux/userData';
+import { reviewPurchaseRequest } from '../../lib/utils/inventoryUtils';
+import { getPurchaseRequestStatusIcon } from './components/PurchaseRequestCard';
+
+const styles = (theme: Theme) =>
+  createStyles({
+    listContainer: {
+      marginBottom: theme.spacing(4),
+    },
+  });
+
+interface EditPurchaseRequestProps extends RouteComponentProps {
+  classes: { listContainer: string };
+}
+
+function EditPurchaseRequest(props: EditPurchaseRequestProps) {
+  const { classes } = props;
+  const history = useHistory();
+  const purchaseRequest: PurchaseRequestRecord = useSelector(selectCurrentPurchaseRequest) || EMPTY_PURCHASE_REQUEST;
+  const userId = useSelector(selectCurrentUserId);
+  const userIsAdmin = useSelector(selectCurrentUserIsAdmin);
+  const [status, setStatus] = useState(purchaseRequest.status);
+
+  // Redirect to InventoryMain if a current purchase request is not found or if the user is not an admin
+  if (purchaseRequest === EMPTY_PURCHASE_REQUEST || !userIsAdmin) {
+    return <Redirect to={'/inventory'} />;
+  }
+
+  const handleSubmit = () => {
+    reviewPurchaseRequest(purchaseRequest, status === PurchaseRequestStatus.APPROVED, userId);
+    history.goBack();
+  };
+
+  return (
+    <BaseScreen title={'Inventory Receipt'} leftIcon="backNav">
+      <List className={classes.listContainer}>
+        <ListItem disableGutters>
+          <ListItemText primary="Edit Approval Status" />
+          <ListItemSecondaryAction>
+            <IconButton edge="end" size="small" onClick={() => setStatus(PurchaseRequestStatus.DENIED)}>
+              {getPurchaseRequestStatusIcon(
+                PurchaseRequestStatus.DENIED,
+                undefined,
+                status === PurchaseRequestStatus.APPROVED,
+              )}
+            </IconButton>
+            <IconButton edge="end" size="small" onClick={() => setStatus(PurchaseRequestStatus.APPROVED)}>
+              {getPurchaseRequestStatusIcon(
+                PurchaseRequestStatus.APPROVED,
+                undefined,
+                status === PurchaseRequestStatus.DENIED,
+              )}
+            </IconButton>
+          </ListItemSecondaryAction>
+        </ListItem>
+      </List>
+      <Button fullWidth label="Save Changes" onClick={handleSubmit} />
+    </BaseScreen>
+  );
+}
+
+export default withStyles(styles)(EditPurchaseRequest);

--- a/src/screens/Inventory/EditPurchaseRequest.tsx
+++ b/src/screens/Inventory/EditPurchaseRequest.tsx
@@ -1,12 +1,12 @@
 import {
-    createStyles,
-    IconButton,
-    List,
-    ListItem,
-    ListItemSecondaryAction,
-    ListItemText,
-    Theme,
-    withStyles
+  createStyles,
+  IconButton,
+  List,
+  ListItem,
+  ListItemSecondaryAction,
+  ListItemText,
+  Theme,
+  withStyles
 } from '@material-ui/core';
 import React, { useState } from 'react';
 import { useSelector } from 'react-redux';
@@ -18,6 +18,7 @@ import { selectCurrentPurchaseRequest } from '../../lib/redux/inventoryData';
 import { EMPTY_PURCHASE_REQUEST, PurchaseRequestStatus } from '../../lib/redux/inventoryDataSlice';
 import { selectCurrentUserId, selectCurrentUserIsAdmin } from '../../lib/redux/userData';
 import { reviewPurchaseRequest } from '../../lib/utils/inventoryUtils';
+import { isOfflineId } from '../../lib/utils/offlineUtils';
 import { getPurchaseRequestStatusIcon } from './components/PurchaseRequestCard';
 
 const styles = (theme: Theme) =>
@@ -40,8 +41,8 @@ function EditPurchaseRequest(props: EditPurchaseRequestProps) {
   const [status, setStatus] = useState(purchaseRequest.status);
 
   // Redirect to InventoryMain if a current purchase request is not found or if the user is not an admin
-  if (purchaseRequest === EMPTY_PURCHASE_REQUEST || !userIsAdmin) {
-    return <Redirect to={'/inventory'} />;
+  if (purchaseRequest === EMPTY_PURCHASE_REQUEST || !userIsAdmin || isOfflineId(purchaseRequest.id)) {
+    return <Redirect to={'/inventory/purchase-requests'} />;
   }
 
   const handleSubmit = () => {

--- a/src/screens/Inventory/EditPurchaseRequest.tsx
+++ b/src/screens/Inventory/EditPurchaseRequest.tsx
@@ -14,6 +14,8 @@ import { Redirect, RouteComponentProps, useHistory } from 'react-router-dom';
 import BaseScreen from '../../components/BaseComponents/BaseScreen';
 import Button from '../../components/Button';
 import { PurchaseRequestRecord } from '../../lib/airtable/interface';
+import { useInternationalization } from '../../lib/i18next/translator';
+import words from '../../lib/i18next/words';
 import { selectCurrentPurchaseRequest } from '../../lib/redux/inventoryData';
 import { EMPTY_PURCHASE_REQUEST, PurchaseRequestStatus } from '../../lib/redux/inventoryDataSlice';
 import { selectCurrentUserId, selectCurrentUserIsAdmin } from '../../lib/redux/userData';
@@ -34,6 +36,7 @@ interface EditPurchaseRequestProps extends RouteComponentProps {
 
 function EditPurchaseRequest(props: EditPurchaseRequestProps) {
   const { classes } = props;
+  const intl = useInternationalization(); 
   const history = useHistory();
   const purchaseRequest: PurchaseRequestRecord = useSelector(selectCurrentPurchaseRequest) || EMPTY_PURCHASE_REQUEST;
   const userId = useSelector(selectCurrentUserId);
@@ -51,6 +54,7 @@ function EditPurchaseRequest(props: EditPurchaseRequestProps) {
   };
 
   return (
+    // TODO: translations
     <BaseScreen title={'Inventory Receipt'} leftIcon="backNav">
       <List className={classes.listContainer}>
         <ListItem disableGutters>
@@ -73,7 +77,7 @@ function EditPurchaseRequest(props: EditPurchaseRequestProps) {
           </ListItemSecondaryAction>
         </ListItem>
       </List>
-      <Button fullWidth label="Save Changes" onClick={handleSubmit} />
+      <Button fullWidth label={intl(words.save)}onClick={handleSubmit} />
     </BaseScreen>
   );
 }

--- a/src/screens/Inventory/PurchaseRequest.tsx
+++ b/src/screens/Inventory/PurchaseRequest.tsx
@@ -92,7 +92,13 @@ function PurchaseRequest(props: PurchaseRequestsProps) {
   };
 
   return (
-    <BaseScreen title={intl(words.inventory_receipt)} leftIcon="backNav" rightIcon={userIsAdmin ? "edit" : undefined} match={match}>
+    // Edit functionality is only enabled for admins and for purchase requests without offline IDs
+    <BaseScreen
+      title={intl(words.inventory_receipt)}
+      leftIcon="backNav"
+      rightIcon={userIsAdmin && !isOfflineId(purchaseRequest.id) ? 'edit' : undefined}
+      match={match}
+    >
       <BaseScrollView>
         <div className={classes.headerContainer}>
           <InventoryInfo

--- a/src/screens/Inventory/components/PurchaseRequestCard.tsx
+++ b/src/screens/Inventory/components/PurchaseRequestCard.tsx
@@ -11,6 +11,7 @@ import { PurchaseRequestRecord } from '../../../lib/airtable/interface';
 import { useInternationalization } from '../../../lib/i18next/translator';
 import words from '../../../lib/i18next/words';
 import { formatDateStringToLocal } from '../../../lib/moment/momentUtils';
+import { setCurrentPurchaseRequestIdInRedux } from '../../../lib/redux/inventoryData';
 import {
   EMPTY_PRODUCT,
   PurchaseRequestStatus,
@@ -69,12 +70,12 @@ interface PurchaseRequestCardProps {
   showSnackbarCallback: () => void;
 }
 
-export const getPurchaseRequestStatusIcon = (status: PurchaseRequestStatus, size?: 'small' | 'large') => {
+export const getPurchaseRequestStatusIcon = (status: PurchaseRequestStatus, size?: 'small' | 'large', grey?: boolean ) => {
   switch (status) {
     case PurchaseRequestStatus.APPROVED:
-      return <CheckCircleOutlineIcon color={'primary'} fontSize={size || 'default'} />;
+      return <CheckCircleOutlineIcon color={grey ? 'secondary': 'primary'} fontSize={size || 'default'} />;
     case PurchaseRequestStatus.DENIED:
-      return <CancelOutlinedIcon color={'error'} fontSize={size || 'default'} />;
+      return <CancelOutlinedIcon color={grey ? 'secondary': 'error'} fontSize={size || 'default'} />;
     default:
       return <HourglassEmptyIcon fontSize={size || 'default'} />;
   }
@@ -107,8 +108,9 @@ function PurchaseRequestCard(props: PurchaseRequestCardProps) {
     <Card variant="outlined" className={classes.cardContainer}>
       <Link
         key={purchaseRequest.id}
-        to={{ pathname: `/inventory/purchase-requests/purchase-request`, state: { purchaseRequest } }}
+        to={{ pathname: `/inventory/purchase-requests/purchase-request` }}
         style={{ flex: 1 }}
+        onClick={() => setCurrentPurchaseRequestIdInRedux(purchaseRequest.id)}
       >
         <CardContent className={classes.cardContent}>
           <div className={classes.leftContent}>


### PR DESCRIPTION
[//]: # "These comments are meant for your reference. They are invisible and don't need to be deleted!"

# What's new in this PR
This PR adds the ability to edit a purchase request status. This led me to restructure the way we manage the Purchase Request details screens: the new workflow matches the `InventoryProfile` and `CustomerProfile` patterns where we set a `currentPurchaseRequestId` in Redux instead of passing the `purchaseReqeust` through `props.location.state`.

This also affects #129 which I'll probably need to revise.

## How to review
**As an admin**
- Open a purchase request that is already reviewed and click the Edit button on the top right to change the status.
- Open a purchase request that **isn't** already reviewed and click the Edit button -- neither button should be greyed out, and selecting a status should save when you go back to the purchase request screen.

**As a non-admin**
- Open any purchase request and you should **not** see an edit button on the top right.

## Relevant Links
n/a

### Online sources
n/a

### Related PRs
- May conflict or lead to some restructuring in #129 

## Next steps
- Update translations

### Screenshots

![image](https://user-images.githubusercontent.com/21160510/115967475-aeae6f00-a4e7-11eb-936c-17b2907376ab.png)
![image](https://user-images.githubusercontent.com/21160510/115967484-b79f4080-a4e7-11eb-8cfe-ec0c15596a87.png)


CC: @julianrkung

[//]: # 'This tags Julian as a default. Feel free to change, or add on anyone who you should be in on the conversation.'