### PR TITLE
Fix nested scroll with BaseScreen

### DIFF
--- a/src/components/BaseComponents/BaseScreen.tsx
+++ b/src/components/BaseComponents/BaseScreen.tsx
@@ -9,6 +9,7 @@ const styles = () =>
       bottom: '56px',
       width: '100%',
       height: 'auto',
+      overflow: 'hidden',
       position: 'absolute',
       padding: '0 25px',
     },

--- a/src/components/BaseComponents/BaseScrollView.tsx
+++ b/src/components/BaseComponents/BaseScrollView.tsx
@@ -1,5 +1,5 @@
+import { createStyles, withStyles } from '@material-ui/core/styles';
 import React from 'react';
-import { withStyles, createStyles } from '@material-ui/core/styles';
 
 const styles = () =>
   createStyles({
@@ -7,7 +7,7 @@ const styles = () =>
       overflow: 'scroll',
       height: '100%',
       width: '100%',
-      paddingBottom: 48,
+      paddingBottom: 56,
     },
   });
 

--- a/src/components/BaseComponents/BaseScrollView.tsx
+++ b/src/components/BaseComponents/BaseScrollView.tsx
@@ -7,7 +7,7 @@ const styles = () =>
       overflow: 'scroll',
       height: '100%',
       width: '100%',
-      paddingBottom: 56,
+      paddingBottom: 56, // height of bottom nav bar
     },
   });
 

--- a/src/screens/Customers/CustomerMain.tsx
+++ b/src/screens/Customers/CustomerMain.tsx
@@ -9,7 +9,6 @@ import { selectAllCustomersArray } from '../../lib/redux/customerDataSlice';
 import TrieTree from '../../lib/utils/TrieTree';
 import { selectCustomersToMeter, selectCustomersToCollect, selectCustomersDone, CustomerStatus } from '../../lib/redux/customerData';
 import BaseScrollView from '../../components/BaseComponents/BaseScrollView';
-import { TabContext, TabPanel } from '@material-ui/lab';
 import CustomerCard from './components/CustomerCard';
 import AttachMoneyIcon from '@material-ui/icons/AttachMoney';
 import FlashOnIcon from '@material-ui/icons/FlashOn';
@@ -47,9 +46,6 @@ const styles = makeStyles((theme: Theme) =>
     },
     tabContent: {
       marginBottom: '50px',
-    },
-    blankDiv: {
-      padding: '10px 0px',
     },
   }));
 
@@ -178,7 +174,6 @@ function CustomerMain(props: CustomerMainProps) {
                 />
               </div>
             ))}
-          <div className={classes.blankDiv}></div>
         </div>
       );
     };


### PR DESCRIPTION
[//]: # "These comments are meant for your reference. They are invisible and don't need to be deleted!"

# What's new in this PR
This PR fixes an issue raised in comments from #85 where the entire outer BaseScreen was scrollable, leading to 2 nested scrollbars on screens that used BaseScreen and BaseScrollview.

See this [Loom of the original scrolling behavior](https://www.loom.com/share/1f21ab1e72054580aba73ec662c65b0a)
## How to review
- Since this modifies the entire `BaseScreen`, look through many screens throughout the app, especially those with `BaseScrollViews` inside to make sure the original behavior is still good.
- On `CustomersMain`, `InventoryMain`, and `PurchaseRequestsMain`, make sure you can't scroll the entire screen but you can still scroll the inside contents (there should only be 1 scroll bar on each page). Scroll the bottom and make sure that no content is cut off. 
## Relevant Links

### Online sources

[//]: # 'Optional - copy links to any tutorial or documentation that was useful to you when working on this PR'

### Related PRs
n/a

## Next steps
n/a

### Screenshots
n/a

CC: @julianrkung

[//]: # 'This tags Julian as a default. Feel free to change, or add on anyone who you should be in on the conversation.'