### PR TITLE
[Inventory] Fix purchase request reviews from list view

### DIFF
--- a/src/screens/Inventory/InventoryProfile.tsx
+++ b/src/screens/Inventory/InventoryProfile.tsx
@@ -15,7 +15,7 @@ import { PurchaseRequestRecord } from '../../lib/airtable/interface';
 import { useInternationalization } from '../../lib/i18next/translator';
 import words from '../../lib/i18next/words';
 import { formatDateStringToLocal } from '../../lib/moment/momentUtils';
-import { selectCurrentInventory, selectCurrentInventoryProduct } from '../../lib/redux/inventoryData';
+import { selectCurrentInventory, selectCurrentInventoryProduct, setCurrentPurchaseRequestIdInRedux } from '../../lib/redux/inventoryData';
 import { EMPTY_INVENTORY } from '../../lib/redux/inventoryDataSlice';
 import { selectIsOnline } from '../../lib/redux/userData';
 import { getInventoryHistory, getInventoryLastUpdated } from '../../lib/utils/inventoryUtils';
@@ -52,9 +52,8 @@ function InventoryProfile(props: InventoryProps) {
   }
 
   const navigateToPurchaseRequest = (purchaseRequest: PurchaseRequestRecord) => {
-    history.push('/inventory/purchase-requests/purchase-request', {
-      purchaseRequest,
-    });
+    setCurrentPurchaseRequestIdInRedux(purchaseRequest.id);
+    history.push('/inventory/purchase-requests/purchase-request');
   };
 
   return (

--- a/src/screens/Inventory/components/PurchaseRequestCard.tsx
+++ b/src/screens/Inventory/components/PurchaseRequestCard.tsx
@@ -99,7 +99,6 @@ function PurchaseRequestCard(props: PurchaseRequestCardProps) {
     } else {
       const newStatus = approved ? PurchaseRequestStatus.APPROVED : PurchaseRequestStatus.DENIED;
       setStatus(newStatus);
-      purchaseRequest.status = newStatus;
       reviewPurchaseRequest(purchaseRequest, approved, userId);
     }
   };


### PR DESCRIPTION
[//]: # "These comments are meant for your reference. They are invisible and don't need to be deleted!"

# What's new in this PR
This PR resolves #117 which was silently blocking purchase request reviews from the list view. It was due to a TypeError caused by attempting to directly modify the readOnly purchaseRequest.status. 

I originally tried fixing this with #129 but shifting to using `currentPurchaseRequestId` in Redux #134 resolved the issue here.

## How to review

Review a purchase request from the list view, open the console to make sure there are no errors, then click the card and check Airtable to see that the status change is saved.

[//]: # 'The order in which to review files and what to expect when testing locally'

## Relevant Links
n/a

### Online sources
n/a

### Related PRs
- Replaces #129

## Next steps
n/a


CC: @julianrkung

[//]: # 'This tags Julian as a default. Feel free to change, or add on anyone who you should be in on the conversation.'