### PR TITLE
[Offline Functionality] Refresh Site Data after Emptying Replay Queue

### DIFF
--- a/src/custom-sw/sw-custom.js
+++ b/src/custom-sw/sw-custom.js
@@ -23,6 +23,11 @@ if ("function" === typeof importScripts) {
             self.skipWaiting();
         });
 
+        // Service worker doesn't wait for a page reload for it to activate
+        self.addEventListener("activate", event => {
+            event.waitUntil(clients.claim())
+        })
+
         const bgSyncPlugin = new workbox.backgroundSync.BackgroundSyncPlugin('PostQueue', {
             maxRetentionTime: 48 * 60, // Retry for max of 48 hours
             onSync: async (event) => {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -17,6 +17,19 @@ setInterval(checkOnline, 10000);
 //refreshes data in the background every 15 min
 setInterval(refreshDataBackground, 900000);
 
+// Set up broadcast channel between the client and service worker
+// this channel is used by the service worker to tell the client 
+// to refresh site data once all requests have been sent.
+const postQueueMonitorChannel = new BroadcastChannel('refresh-data-channel');
+
+postQueueMonitorChannel.onmessage = (event) => {
+  if (event.data && event.data.replayQueueLength === 0) {
+    console.log("Offline requests finished sending. Refreshing data...")
+    refreshDataBackground().then(() => console.log("...Finished refreshing data"))
+  }
+}
+
+
 ReactDOM.render(
   <Provider store={store}>
     <PersistGate loading={null} persistor={persistor}>

--- a/src/lib/redux/customerData.ts
+++ b/src/lib/redux/customerData.ts
@@ -11,6 +11,7 @@ import {
     addPayment,
     addMeterReading,
     removeMeterReading,
+    clearCustomerDataForSite
 } from './customerDataSlice';
 import { isBeforeCurrentPeriod } from '../moment/momentUtils';
 import { selectCurrentSiteId } from './siteData';
@@ -34,6 +35,7 @@ export const refreshCustomerData = (site: SiteRecord): void => {
             payments,
             meterReadings
         };
+        store.dispatch(clearCustomerDataForSite(siteId));
         store.dispatch(saveCustomerData(customerData));
     }
 };
@@ -128,7 +130,7 @@ export const selectAmountOwedInCurrentPeriodByCustomerId = createSelector(
     getCustomerId,
     (state, customerId) => {
         const currentPeriodMeterReadings =
-        selectMeterReadingsByCustomerId(state, customerId)?.filter(meterReading => !isBeforeCurrentPeriod(meterReading.date));
+            selectMeterReadingsByCustomerId(state, customerId)?.filter(meterReading => !isBeforeCurrentPeriod(meterReading.date));
         if (currentPeriodMeterReadings) {
             return currentPeriodMeterReadings.reduce((totalAmountOwed, meterReading: MeterReadingRecord) => totalAmountOwed + meterReading.amountBilled, 0);
         }

--- a/src/lib/redux/customerDataSlice.ts
+++ b/src/lib/redux/customerDataSlice.ts
@@ -5,6 +5,7 @@ import { CustomerRecord, MeterReadingRecord, PaymentRecord, SiteId } from '../ai
 import { setCurrentSiteId } from './siteDataSlice';
 import { RootState } from './store';
 import moment from 'moment';
+import { isOfflineId } from '../utils/offlineUtils';
 
 const customersAdapter = createEntityAdapter<CustomerRecord>();
 const paymentsAdapter = createEntityAdapter<PaymentRecord>({
@@ -55,9 +56,9 @@ interface customerDataSliceState {
 }
 
 export enum MeterType {
-  ANALOG_METER = 'Analog Meter',
-  SMART_METER = 'Smart Meter',
-  NO_METER = 'No Meter',
+    ANALOG_METER = 'Analog Meter',
+    SMART_METER = 'Smart Meter',
+    NO_METER = 'No Meter',
 }
 
 export const EMPTY_CUSTOMER: CustomerRecord = {
@@ -139,7 +140,7 @@ const customerDataSlice = createSlice({
             meterReadingsAdapter.addOne(state.sitesCustomers[siteId].meterReadings, payload);
         },
         removeMeterReading(state, action) {
-            const { siteId, id} = action.payload;
+            const { siteId, id } = action.payload;
             meterReadingsAdapter.removeOne(state.sitesCustomers[siteId].meterReadings, id);
         },
         updateCustomer(state, action) {
@@ -153,6 +154,15 @@ const customerDataSlice = createSlice({
         addPayment(state, action) {
             const { siteId, ...payload } = action.payload;
             paymentsAdapter.addOne(state.sitesCustomers[siteId].payments, payload);
+        },
+        clearCustomerDataForSite(state, action) {
+            const siteId = action.payload;
+            state.sitesCustomers[siteId] = JSON.parse(JSON.stringify(EMPTY_SITE_CUSTOMER_DATA));
+
+            // We only reset the current customer ID if it's offline in case this clear data was for a refresh
+            if (isOfflineId(state.currentCustomerId)) {
+                state.currentCustomerId = initialState.currentCustomerId
+            }
         }
     },
     extraReducers: {
@@ -164,5 +174,5 @@ const customerDataSlice = createSlice({
     }
 });
 
-export const { saveCustomerData, setCurrentCustomerId, addCustomer, updateCustomer, addPayment, addMeterReading, removeMeterReading } = customerDataSlice.actions;
+export const { saveCustomerData, setCurrentCustomerId, addCustomer, updateCustomer, addPayment, addMeterReading, removeMeterReading, clearCustomerDataForSite } = customerDataSlice.actions;
 export default customerDataSlice.reducer;

--- a/src/lib/redux/inventoryData.ts
+++ b/src/lib/redux/inventoryData.ts
@@ -22,7 +22,8 @@ import {
   setCurrInventoryId,
   setCurrPurchaseRequestId,
   updateInventoryQuantity,
-  updatePurchaseRequest
+  updatePurchaseRequest,
+  clearInventoryData
 } from './inventoryDataSlice';
 import { selectCurrentSiteId } from './siteData';
 import { RootState, store } from './store';
@@ -92,6 +93,7 @@ export const refreshInventoryData = (site: SiteRecord): void => {
       purchaseRequests,
       inventoryUpdates,
     };
+    store.dispatch(clearInventoryData(siteId));
     store.dispatch(saveInventoryData(inventoryData));
   }
 };

--- a/src/lib/redux/inventoryDataSlice.ts
+++ b/src/lib/redux/inventoryDataSlice.ts
@@ -3,6 +3,7 @@
 import { createEntityAdapter, createSlice, EntityState } from '@reduxjs/toolkit';
 import moment from 'moment';
 import { InventoryRecord, InventoryUpdateRecord, ProductRecord, PurchaseRequestRecord } from '../airtable/interface';
+import { isOfflineId } from '../utils/offlineUtils';
 import { setCurrentSiteId } from './siteDataSlice';
 import { RootState } from './store';
 
@@ -190,6 +191,22 @@ const inventoryDataSlice = createSlice({
     addProduct(state, action) {
       productsAdapter.addOne(state.products, action.payload);
     },
+    clearInventoryData(state, action) {
+      const siteId = action.payload;
+      state.products = productsAdapter.getInitialState()
+      state.sitesInventory[siteId] = JSON.parse(JSON.stringify(EMPTY_SITE_INVENTORY_DATA));
+
+      // We only reset the currentInventoryId and currentPurchaseRequestId if they're offline IDs
+      // in case the clear will be followed up with a background refresh 
+      if (isOfflineId(state.currentInventoryId)) {
+        state.currentInventoryId = initialState.currentInventoryId
+      }
+
+      if (isOfflineId(state.currentPurchaseRequestId)) {
+        state.currentPurchaseRequestId = initialState.currentPurchaseRequestId
+      }
+
+    }
   },
   extraReducers: {
     // If the site changes, reset currentInventoryId
@@ -210,5 +227,6 @@ export const {
   setCurrInventoryId,
   setCurrPurchaseRequestId,
   addProduct,
+  clearInventoryData
 } = inventoryDataSlice.actions;
 export default inventoryDataSlice.reducer;

--- a/src/lib/redux/siteData.ts
+++ b/src/lib/redux/siteData.ts
@@ -1,6 +1,6 @@
 import { createSelector } from '@reduxjs/toolkit';
 import { SiteRecord, TariffPlanRecord } from '../airtable/interface';
-import { setCurrentSiteId, updateTariffPlan, updateSite } from './siteDataSlice';
+import { setCurrentSiteId, updateTariffPlan, updateSite, clearSiteData } from './siteDataSlice';
 import { RootState, store } from './store';
 
 export const setCurrentSite = (newSite: any): void => {
@@ -15,8 +15,12 @@ export const selectCurrentSiteInformation = createSelector(
   (siteId, state) => state.siteData.sites[siteId].siteInformation)
 
 export const selectCurrentSiteGracePeriod = createSelector(
-  selectCurrentSiteInformation, 
-  (currentSiteRecord : SiteRecord) => currentSiteRecord.gracePeriod)
+  selectCurrentSiteInformation,
+  (currentSiteRecord: SiteRecord) => currentSiteRecord.gracePeriod)
+
+export const clearSiteDataInRedux = (): void => {
+  store.dispatch(clearSiteData());
+};
 
 
 // Returns all SiteRecord[] information
@@ -32,6 +36,6 @@ export const updateTariffPlanInRedux = (tariffPlan: Partial<TariffPlanRecord>) =
   store.dispatch(updateTariffPlan(tariffPlanUpdates));
 };
 
-export const updateSiteInRedux = (siteUpdates : Partial<SiteRecord>) => {
+export const updateSiteInRedux = (siteUpdates: Partial<SiteRecord>) => {
   store.dispatch(updateSite(siteUpdates))
 }

--- a/src/lib/redux/siteDataSlice.ts
+++ b/src/lib/redux/siteDataSlice.ts
@@ -129,9 +129,14 @@ const siteDataSlice = createSlice({
       const { id } = action.payload;
       const newSiteInformation = { ...state.sites[id].siteInformation, ...action.payload };
       state.sites[id].siteInformation = newSiteInformation;
+    },
+
+    // Clear the main site data but leave the site ID in case this is called for a refresh
+    clearSiteData(state) {
+      return { ...initialState, currentSiteId: state.currentSiteId }
     }
   },
 });
 
-export const { setLoadingForSiteData, saveSiteData, setCurrentSiteId, updateTariffPlan, updateSite } = siteDataSlice.actions;
+export const { setLoadingForSiteData, saveSiteData, setCurrentSiteId, updateTariffPlan, updateSite, clearSiteData } = siteDataSlice.actions;
 export default siteDataSlice.reducer;


### PR DESCRIPTION
[//]: # "These comments are meant for your reference. They are invisible and don't need to be deleted!"

# What's new in this PR
This PR implements a channel for the service worker and client to communicate. This is used to trigger a data refresh once all requests stored offline have finished being replayed. We only refresh once the queue is fully empty in order to not lose any offline objects in the redux store that would otherwise be lost if we refreshed site data with requests still queued.

[//]: # "Describe what's new in this PR in a few lines. A description and bullet points for specifics will suffice."

## How to review
1. `npm run build` to build a production environment
2. `serve -s build` to run the production environment
3. Go to localhost:5000 and clear your site data to make sure you get the latest changes in the PR
4. Refresh the page to make sure you get the latest service worker installed
5. log in using the credentials `username: admin ; password: test`.
6. Go offline by opening up devtools --> Application -->  Service Workers --> check the "offline" box
7. Create 2 "Inventory updates" while offline and make sure that they haven't persisted to Airtable
8. Uncheck the "Offline" box from step 6
9. Check that the inventory updates have now persisted to Airtable and that in console you should've seen a `Offline requests finished sending. Refreshing data...` log message
10. Check the redux store to make sure that the 2 inventory updates you created have Airtable IDs and no longer have offline IDs

[//]: # 'The order in which to review files and what to expect when testing locally'

## Relevant Links

### Online sources
https://developers.google.com/web/tools/workbox/reference-docs/latest/module-workbox-background-sync.Queue 

[//]: # 'Optional - copy links to any tutorial or documentation that was useful to you when working on this PR'

### Related PRs

[//]: # "Optional - related PRs you're waiting on/ PRs that will conflict, etc; if this is a refactor, feel free to add PRs that previously modified this code"

## Next steps

[//]: # "What's NOT in this PR, doesn't work yet, and/or still needs to be done"

### Screenshots

[//]: # "Add screenshots of expected behavior - GIFs if you're feeling fancy!"

CC: @julianrkung

[//]: # 'This tags Julian as a default. Feel free to change, or add on anyone who you should be in on the conversation.'