### PR TITLE
Fix text cutoff on new inventory screen

### DIFF
--- a/src/screens/Inventory/AddInventory.tsx
+++ b/src/screens/Inventory/AddInventory.tsx
@@ -13,14 +13,8 @@ import { InventoryRecord } from '../../lib/airtable/interface';
 import { createInventoryAndUpdate, createProductInventoryAndUpdate } from '../../lib/airtable/request';
 import { useInternationalization } from '../../lib/i18next/translator';
 import words from '../../lib/i18next/words';
-import {
-  setCurrentInventoryIdInRedux
-} from '../../lib/redux/inventoryData';
-import {
-
-  selectAllCurrentSiteInventoryArray,
-  selectAllProducts
-} from '../../lib/redux/inventoryDataSlice';
+import { setCurrentInventoryIdInRedux } from '../../lib/redux/inventoryData';
+import { selectAllCurrentSiteInventoryArray, selectAllProducts } from '../../lib/redux/inventoryDataSlice';
 import { selectCurrentSiteId } from '../../lib/redux/siteData';
 import { selectCurrentUserId } from '../../lib/redux/userData';
 import { generateInventoryRecord, generateProductRecord } from '../../lib/utils/inventoryUtils';
@@ -112,7 +106,7 @@ function AddInventory(props: AddInventoryProps) {
       <form onSubmit={formik.handleSubmit} noValidate>
         <Autocomplete
           aria-required
-          style={{ marginBottom: 8 }}
+          style={{ marginTop: 8, marginBottom: 8 }}
           filterOptions={(options, params) => {
             const filtered = filter(options, params);
             filtered.push(NEW_PRODUCT_LABEL);


### PR DESCRIPTION
[//]: # "These comments are meant for your reference. They are invisible and don't need to be deleted!"

# What's new in this PR
This PR resolves #141 by adding a top margin.

## How to review
- Look at the Add Inventory page, select the field, and make sure no text is cut off.

## Relevant Links

### Online sources
n/a

### Related PRs
Caused by #138 

## Next steps
n/a

### Screenshots

![image](https://user-images.githubusercontent.com/21160510/116494976-e48c8400-a856-11eb-9c00-d45d6e0db531.png)

CC: @julianrkung

[//]: # 'This tags Julian as a default. Feel free to change, or add on anyone who you should be in on the conversation.'