### PR TITLE
Login and Loading Early Exits

### DIFF
--- a/src/components/BaseComponents/LoadingComponent.tsx
+++ b/src/components/BaseComponents/LoadingComponent.tsx
@@ -1,5 +1,6 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { withStyles, createStyles } from '@material-ui/core/styles';
+import { useHistory } from 'react-router';
 
 const styles = () =>
   createStyles({
@@ -19,6 +20,17 @@ interface LoadingComponentProps {
 
 const LoadingComponent = (props: LoadingComponentProps) => {
   const { classes } = props;
+  const history = useHistory();
+
+  // If a user is stuck on the loading screen for more than 15 seconds, we send them back to the login screen
+  useEffect(() => {
+    const timeoutId = setTimeout(() => history.push('/login'), 15000)
+    return () => {
+      clearTimeout(timeoutId)
+      console.log("Timeout cleared")
+    }
+  })
+
   return (
     <div className={classes.loadingComponent}>
       <h1> Loading ... </h1>

--- a/src/components/BaseComponents/LoadingComponent.tsx
+++ b/src/components/BaseComponents/LoadingComponent.tsx
@@ -22,12 +22,11 @@ const LoadingComponent = (props: LoadingComponentProps) => {
   const { classes } = props;
   const history = useHistory();
 
-  // If a user is stuck on the loading screen for more than 15 seconds, we send them back to the login screen
+  // If a user is stuck on the loading screen for more than 20 seconds, we send them back to the login screen
   useEffect(() => {
-    const timeoutId = setTimeout(() => history.push('/login'), 15000)
+    const timeoutId = setTimeout(() => history.push('/login'), 20000)
     return () => {
       clearTimeout(timeoutId)
-      console.log("Timeout cleared")
     }
   })
 

--- a/src/screens/Login.tsx
+++ b/src/screens/Login.tsx
@@ -104,6 +104,7 @@ function Login() {
             onClick={() => {
               formik.setFieldValue('submitAction', LoginAction.LOGIN);
             }}
+            disabled={!isOnline}
           />
           <Button
             loading={loadingButton === LoginAction.CREATE}
@@ -111,6 +112,7 @@ function Login() {
             onClick={() => {
               formik.setFieldValue('submitAction', LoginAction.CREATE);
             }}
+            disabled={!isOnline}
             fullWidth
             variant="outlined"
           />


### PR DESCRIPTION
[//]: # "These comments are meant for your reference. They are invisible and don't need to be deleted!"

# What's new in this PR
This PR:
1. Disables the "login" and "create account" buttons in the login screen if the user is not online
2. Exits out of the "Loading" screen if the user is on the screen for more than 15 seconds

Temporary fix for: https://github.com/calblueprint/meepanyar/issues/90

[//]: # "Describe what's new in this PR in a few lines. A description and bullet points for specifics will suffice."

## How to review

### Disabled Buttons
1. Run the frontend and not the backend and make sure the "Login" and "Create Account" buttons are disabled after some time

### Exit out of loading screen
1. Run the frontend and backend
2. Log in to any account, but immediately after you press "Login" and enter the "Loading" screen, stop running the backend so that the you remain stuck in the "Loading" screen
3. You should be brought back to the login page after 15 seconds in the loading screen
4. Run the backend again and log in as usual and get to the home page and make sure that after 15 seconds you aren't redirected back to the login page (it should only happen if you're stuck in the loading screen)

[//]: # 'The order in which to review files and what to expect when testing locally'

## Relevant Links

### Online sources

[//]: # 'Optional - copy links to any tutorial or documentation that was useful to you when working on this PR'

### Related PRs

[//]: # "Optional - related PRs you're waiting on/ PRs that will conflict, etc; if this is a refactor, feel free to add PRs that previously modified this code"

## Next steps

[//]: # "What's NOT in this PR, doesn't work yet, and/or still needs to be done"

### Screenshots

[//]: # "Add screenshots of expected behavior - GIFs if you're feeling fancy!"

CC: @julianrkung

[//]: # 'This tags Julian as a default. Feel free to change, or add on anyone who you should be in on the conversation.'