### PR TITLE
[Translation Support] Apply translations (src/Components)

### DIFF
--- a/src/components/CameraButton.tsx
+++ b/src/components/CameraButton.tsx
@@ -2,6 +2,8 @@ import { Button as MaterialButton, FormHelperText, InputLabel, makeStyles, Theme
 import { createStyles } from '@material-ui/core/styles';
 import React from 'react';
 import { navigateToCamera } from '../lib/utils/cameraUtils';
+import { useInternationalization } from '../lib/i18next/translator';
+import words from '../lib/i18next/words';
 
 interface CameraButtonProps {
   id: string;
@@ -42,6 +44,7 @@ const useStyles = makeStyles((theme: Theme) =>
 );
 
 function CameraButton(props: CameraButtonProps) {
+  const intl = useInternationalization(); 
   const classes = useStyles(props);
   const { photoUri, preservedState, goBack, staticPreview } = props;
 
@@ -69,7 +72,7 @@ function CameraButton(props: CameraButtonProps) {
           <img width="100%" src={photoUri} alt="user-uploaded image" />
         ) : (
           <Typography variant="button" color={props.error ? 'error' : 'primary'}>
-            + Add Photo
+            + {intl(words.add_x, words.photo)}
           </Typography>
         )}
       </MaterialButton>

--- a/src/components/OfflineDialog.tsx
+++ b/src/components/OfflineDialog.tsx
@@ -11,6 +11,8 @@ import { createStyles, makeStyles } from '@material-ui/core/styles';
 import CloudOffIcon from '@material-ui/icons/CloudOff';
 import React, { useState } from 'react';
 import Button from './Button';
+import { useInternationalization } from '../lib/i18next/translator';
+import words from '../lib/i18next/words';
 
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
@@ -34,6 +36,7 @@ interface OfflineDialogProps {
 }
 
 export default function OfflineDialog(props: OfflineDialogProps): JSX.Element {
+  const intl = useInternationalization();
   const classes = useStyles();
   const { headingText, bodyText, closeAction } = props;
   const [open, setOpen] = useState(props.open);
@@ -57,7 +60,7 @@ export default function OfflineDialog(props: OfflineDialogProps): JSX.Element {
         <DialogContentText align="center">{bodyText}</DialogContentText>
       </DialogContent>
       <DialogActions>
-        <Button fullWidth label="Go Back" onClick={() => handleClose()} />
+        <Button fullWidth label={intl(words.go_back)} onClick={() => handleClose()} />
       </DialogActions>
     </Dialog>
   );

--- a/src/components/TextField.tsx
+++ b/src/components/TextField.tsx
@@ -2,6 +2,8 @@ import { InputAdornment, InputLabel, makeStyles, TextField } from '@material-ui/
 import { createStyles, Theme } from '@material-ui/core/styles';
 import ErrorIcon from '@material-ui/icons/Error';
 import React, { useState } from 'react';
+import { useInternationalization } from '../lib/i18next/translator';
+import words from '../lib/i18next/words';
 
 // TODO: @wangannie: make onChange not optional
 interface TextFieldProps {
@@ -37,6 +39,7 @@ const styles = makeStyles((theme: Theme) =>
 
 // TODO: Rename component
 function Field(props: TextFieldProps) {
+  const intl = useInternationalization();
   const classes = styles(props);
   const [focused, setFocused] = useState(false);
 
@@ -63,7 +66,7 @@ function Field(props: TextFieldProps) {
         InputProps={{
           endAdornment:
           props.unit || props.currency ? (
-            <InputAdornment position="end">{props.currency ? 'Ks' : `${props.unit}(s)`}</InputAdornment>
+            <InputAdornment position="end">{props.currency ? intl(words.ks) : `${props.unit}(${intl(words.s)})`}</InputAdornment>
           ) : props.error ? (
             <ErrorIcon color="error" />
           ) : undefined,

--- a/src/lib/i18next/resources.js
+++ b/src/lib/i18next/resources.js
@@ -127,6 +127,7 @@ module.exports = {
       "General Information": "အထွေထွေအချတ်အလတ်များ",
       "Get started": "စလိုက်ကြစို့",
       "Give access [to user]": "ဝင်ခွင့်ပေးမည်",
+      "Go Back": "Go Back",
       "Go to my site": "ကိုယ့်ဆိုက်သို့သွားမည်",
       "Go to settings to change this.": "၎င်းကိုပြောင်းလဲရန် Settings သို့သွားပါ။",
       "Has meter": "Has meter",

--- a/src/lib/i18next/words.ts
+++ b/src/lib/i18next/words.ts
@@ -124,6 +124,7 @@ export default {
   "general_information": "General Information",
   "get_started": "Get started",
   "give_access_to_user": "Give access [to user]",
+  "go_back": "Go Back",
   "go_to_my_site": "Go to my site",
   "go_to_settings_to_change_this": "Go to settings to change this.",
   "has_meter": "Has meter",


### PR DESCRIPTION
# In this PR

In this PR, we follow the steps in the ["Applying Our Hook" section](https://www.notion.so/calblueprint/Translation-Support-Design-Document-7703018a8c4e403dab8aaa49d2a322e7#a7e5cbd6962e4dbd850b724c3eee7b18) of our [roadmap for translation support](https://www.notion.so/calblueprint/Translation-Support-Design-Document-7703018a8c4e403dab8aaa49d2a322e7#cfc52fc0865e4bb2b140e54d395343ba) in order to translate `src/Components` for `meepanyar`. 

## Coverage
- [ ] `screens/Customers` e.g. (`CustomerMain.tsx`)
- [ ] `screens/Camera`
- [ ] `screens/FinancialSummary`
- [ ] `screens/Home`
- [ ] `screens/Inventory`
- [ ] `screens/Profile`
- [x] `src/Components`

## How to Review
1. Change your browser device setting to Burmese (or return "my" in `device.ts#detectLanguage`)
2. Run the application and navigate to the screens corresponding to `src/Customers`. 
3. Ensure nothing is breaking
4. Test in English and ensure wording is still correct

cc: @julianrkung 
